### PR TITLE
Campo soporte oxígeno (beta03)

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -97,6 +97,7 @@ DDL = [
         control_tronco              TEXT,
         control_cabeza              TEXT,
         control_de_piernas          TEXT,
+        soporte_oxigeno             BOOLEAN NOT NULL DEFAULT FALSE,
         observaciones_posturales    TEXT,
         altura_total_in             NUMERIC(7,3) CHECK(altura_total_in IS NULL OR (altura_total_in >= 0 AND altura_total_in <= 9999.999)),
         peso_kg                     NUMERIC(7,3) CHECK(peso_kg IS NULL OR (peso_kg >= 0 AND peso_kg <= 9999.999)),
@@ -214,6 +215,7 @@ DDL = [
     "ALTER TABLE estudios_socioeconomicos ADD COLUMN IF NOT EXISTS finalizado_at TIMESTAMPTZ NULL",
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS finalizado_at TIMESTAMPTZ NULL",
     "ALTER TABLE usuarios ADD COLUMN IF NOT EXISTS avatar_url TEXT",
+    "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE",
 ]
 
 

--- a/backend/migrations/0013_add_soporte_oxigeno_to_solicitudes_tecnicas.sql
+++ b/backend/migrations/0013_add_soporte_oxigeno_to_solicitudes_tecnicas.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.solicitudes_tecnicas
+ADD COLUMN IF NOT EXISTS soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -114,6 +114,7 @@ class GuardarBorradorRequest(BaseModel):
     control_tronco: Optional[str] = None
     control_cabeza: Optional[str] = None
     control_de_piernas: Optional[str] = None
+    soporte_oxigeno: Optional[bool] = None
     observaciones_posturales: Optional[str] = None
     unidad_medida: Optional[str] = None
     altura_total_in: Optional[str] = None
@@ -650,12 +651,12 @@ def _create_borrador(
             """
             INSERT INTO solicitudes_tecnicas
                 (beneficiario_id, usuario_id, entorno, control_tronco, control_cabeza,
-                 control_de_piernas, observaciones_posturales, altura_total_in, peso_kg,
+                 control_de_piernas, soporte_oxigeno, observaciones_posturales, altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura,
                  unidad_peso_captura, foto_url, entidad_solicitante, prioridad,
                  justificacion, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -665,6 +666,7 @@ def _create_borrador(
                 body.control_tronco,
                 body.control_cabeza,
                 body.control_de_piernas,
+                bool(body.soporte_oxigeno),
                 body.observaciones_posturales,
                 _parse_decimal_or_none(body.altura_total_in),
                 _parse_decimal_or_none(body.peso_kg),
@@ -888,6 +890,7 @@ def _patch_solicitud(db: _DBAdapter, body: GuardarBorradorRequest, solicitud_id:
         ("control_tronco", body.control_tronco),
         ("control_cabeza", body.control_cabeza),
         ("control_de_piernas", body.control_de_piernas),
+        ("soporte_oxigeno", body.soporte_oxigeno),
         ("observaciones_posturales", body.observaciones_posturales),
         ("entidad_solicitante", body.entidad_solicitante),
         ("prioridad", body.prioridad),

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -415,6 +415,7 @@ class SolicitudCreateRequest(BaseModel):
     control_tronco: str
     control_cabeza: str
     control_de_piernas: str
+    soporte_oxigeno: bool = False
     observaciones_posturales: Optional[str] = None
     unidad_medida: str = "in"
     altura_total_in: Optional[Decimal] = None
@@ -549,6 +550,7 @@ class SolicitudUpdateRequest(BaseModel):
     control_tronco: Optional[str] = None
     control_cabeza: Optional[str] = None
     control_de_piernas: Optional[str] = None
+    soporte_oxigeno: Optional[bool] = None
     observaciones_posturales: Optional[str] = None
     unidad_medida: Optional[str] = None
     altura_total_in: Optional[Decimal] = None
@@ -1414,11 +1416,11 @@ def crear_solicitud(
             """
             INSERT INTO solicitudes_tecnicas
                 (beneficiario_id, usuario_id, entorno, control_tronco, control_cabeza, control_de_piernas,
-                 observaciones_posturales, altura_total_in, peso_kg,
+                 soporte_oxigeno, observaciones_posturales, altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura, unidad_peso_captura, foto_url,
                  entidad_solicitante, prioridad, justificacion, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -1428,6 +1430,7 @@ def crear_solicitud(
                 body.control_tronco,
                 body.control_cabeza,
                 body.control_de_piernas,
+                body.soporte_oxigeno,
                 body.observaciones_posturales,
                 body.altura_total_in,
                 body.peso_kg,

--- a/backend/tests/test_tecnica.py
+++ b/backend/tests/test_tecnica.py
@@ -34,6 +34,16 @@ def _create_user_and_login(client, admin_headers: dict, *, suffix: str, rol: str
 
 
 class TestTecnicaRbac:
+    def test_soporte_oxigeno_persiste(self, client, tecnico_headers, sample_estudio):
+        payload = _solicitud_payload(sample_estudio["beneficiario_id"])
+        payload["soporte_oxigeno"] = True
+        create_response = client.post("/api/solicitudes", headers=tecnico_headers, json=payload)
+        assert create_response.status_code == 201
+        solicitud_id = create_response.json()["solicitud_id"]
+        get_response = client.get(f"/api/solicitudes/{solicitud_id}", headers=tecnico_headers)
+        assert get_response.status_code == 200
+        assert get_response.json()["soporte_oxigeno"] is True
+
     def test_unidad_cm_no_convierte_en_borrador(self, client, tecnico_headers, sample_estudio):
         """Borradores must store measurement values verbatim (no unit conversion).
         Conversion to canonical units (inches/lb) happens only at final submission."""

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -208,6 +208,21 @@
               <p class="field-error hidden text-red-600 text-xs mt-1" id="control_de_piernas-error" data-error-for="control_de_piernas" role="alert"></p>
             </div>
             <div class="md:col-span-2 space-y-2">
+              <fieldset>
+                <legend class="block text-sm font-semibold text-slate-700 mb-2">¿Requiere soporte para oxígeno?</legend>
+                <div class="flex items-center gap-6">
+                  <label class="inline-flex items-center">
+                    <input class="text-primary focus:ring-primary h-4 w-4" name="soporte_oxigeno" type="radio" value="true" />
+                    <span class="ml-2 text-sm font-medium text-slate-700">Sí</span>
+                  </label>
+                  <label class="inline-flex items-center">
+                    <input class="text-primary focus:ring-primary h-4 w-4" name="soporte_oxigeno" type="radio" value="false" checked />
+                    <span class="ml-2 text-sm font-medium text-slate-700">No</span>
+                  </label>
+                </div>
+              </fieldset>
+            </div>
+            <div class="md:col-span-2 space-y-2">
                 <label class="block text-sm font-semibold text-slate-700"
                   >Observaciones Posturales (Escoliosis, Cifosis, etc.)</label
                 >
@@ -883,6 +898,12 @@
               setVal("control_cabeza", data.control_cabeza);
               setVal("control_de_piernas", data.control_de_piernas);
 
+              // Radio group — restore by checking the matching option
+              const oxiRadioA = document.querySelector(
+                `[name="soporte_oxigeno"][value="${data.soporte_oxigeno === true ? "true" : "false"}"]`,
+              );
+              if (oxiRadioA) oxiRadioA.checked = true;
+
               // Set textarea
               setVal("observaciones_posturales", data.observaciones_posturales);
 
@@ -956,6 +977,10 @@
             setVal("control_tronco", data.control_tronco);
             setVal("control_cabeza", data.control_cabeza);
             setVal("control_de_piernas", data.control_de_piernas);
+            const oxiRadioB = document.querySelector(
+              `[name="soporte_oxigeno"][value="${data.soporte_oxigeno === true ? "true" : "false"}"]`,
+            );
+            if (oxiRadioB) oxiRadioB.checked = true;
             setVal("observaciones_posturales", data.observaciones_posturales);
             if (data.observaciones_posturales && data.observaciones_posturales.trim()) {
               const chk = document.querySelector('[name="tiene_observaciones"]');
@@ -1824,6 +1849,7 @@
           control_tronco: get("control_tronco"),
           control_cabeza: get("control_cabeza"),
           control_de_piernas: get("control_de_piernas"),
+          soporte_oxigeno: get("soporte_oxigeno") === "true",
           observaciones_posturales: get("observaciones_posturales") || null,
           altura_total_in: toStrOrNull(get("altura_total_in")),
           peso_kg: toStrOrNull(get("peso_kg")),
@@ -2004,6 +2030,7 @@
             control_tronco: tecnicaData.control_tronco || null,
             control_cabeza: tecnicaData.control_cabeza || null,
             control_de_piernas: tecnicaData.control_de_piernas || null,
+            soporte_oxigeno: tecnicaData.soporte_oxigeno ?? false,
             observaciones_posturales: tecnicaData.observaciones_posturales || null,
             altura_total_in: tecnicaData.altura_total_in || null,
             peso_kg: tecnicaData.peso_kg || null,
@@ -2164,6 +2191,7 @@
           control_tronco: get("control_tronco"),
           control_cabeza: get("control_cabeza"),
           control_de_piernas: get("control_de_piernas"),
+          soporte_oxigeno: get("soporte_oxigeno") === "true",
           observaciones_posturales: get("observaciones_posturales"),
           altura_total_in: toStrOrNull(get("altura_total_in")),
           peso_kg: toStrOrNull(get("peso_kg")),


### PR DESCRIPTION
Añade el campo **¿Requiere soporte para oxígeno?** a la Solicitud Técnica y lo persiste en Supabase.

Reelaborado a partir de #62 para que aplique sobre `beta03` (donde el front se movió a `front/Capturista-view/` y el backend divergió).

## Cambios
- **DB**: migración `0013` + `ALTER` en `init_db.py` (columna `soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE`). Aplicada a Supabase.
- **Backend**: campo en `SolicitudCreateRequest`/`SolicitudUpdateRequest` + INSERT de `crear_solicitud` (`tecnica.py`), y en `guardar_borrador.py` (INSERT + PATCH parcial), que es el otro camino que escribe `solicitudes_tecnicas` en beta03.
- **Frontend** (`front/Capturista-view/tecnica.html`): radios Sí/No, recolección en los 3 payloads (draft local, guardar-borrador, POST/PATCH) y restauración al reanudar borrador.
- **Test**: `test_soporte_oxigeno_persiste` (POST → GET round-trip).

## Fix sobre #62
El #62 tenía los dos radios con `name` distinto (`soporte_oxigeno` vs `requiere_soporte_oxigeno`), así que no eran mutuamente excluyentes y el "No" no registraba. Corregido: ambos comparten `name="soporte_oxigeno"`.

Supersedes #62. Crédito a @Katherine-MV por la feature original.