### PR TITLE
fix(tecnica): org leaders can read solicitudes + repair padecimiento rename (#54)

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -121,7 +121,6 @@ DDL = [
         control_de_piernas          TEXT,
         padecimiento    TEXT,
         soporte_oxigeno             BOOLEAN NOT NULL DEFAULT FALSE,
-        observaciones_posturales    TEXT,
         altura_total_in             NUMERIC(7,3) CHECK(altura_total_in IS NULL OR (altura_total_in >= 0 AND altura_total_in <= 9999.999)),
         peso_kg                     NUMERIC(7,3) CHECK(peso_kg IS NULL OR (peso_kg >= 0 AND peso_kg <= 9999.999)),
         medida_cabeza_asiento       NUMERIC(7,3) CHECK(medida_cabeza_asiento IS NULL OR (medida_cabeza_asiento >= 0 AND medida_cabeza_asiento <= 9999.999)),
@@ -239,6 +238,7 @@ DDL = [
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS finalizado_at TIMESTAMPTZ NULL",
     "ALTER TABLE usuarios ADD COLUMN IF NOT EXISTS avatar_url TEXT",
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE",
+    "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS padecimiento TEXT",
 ]
 
 

--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -116,7 +116,6 @@ class GuardarBorradorRequest(BaseModel):
     control_de_piernas: Optional[str] = None
     padecimiento: Optional[str] = None
     soporte_oxigeno: Optional[bool] = None
-    observaciones_posturales: Optional[str] = None
     unidad_medida: Optional[str] = None
     altura_total_in: Optional[str] = None
     peso_kg: Optional[str] = None
@@ -650,8 +649,8 @@ def _create_borrador(
             """
             INSERT INTO solicitudes_tecnicas
                 (beneficiario_id, usuario_id, entorno, control_tronco, control_cabeza,
-                 control_de_piernas, padecimiento, altura_total_in, peso_kg,
-                 soporte_oxigeno, observaciones_posturales,
+                 control_de_piernas, padecimiento, soporte_oxigeno,
+                 altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura,
                  unidad_peso_captura, foto_url, entidad_solicitante, prioridad,
@@ -668,7 +667,6 @@ def _create_borrador(
                 body.control_de_piernas,
                 body.padecimiento,
                 bool(body.soporte_oxigeno),
-                body.observaciones_posturales,
                 _parse_decimal_or_none(body.altura_total_in),
                 _parse_decimal_or_none(body.peso_kg),
                 _parse_decimal_or_none(body.medida_cabeza_asiento),
@@ -891,7 +889,6 @@ def _patch_solicitud(db: _DBAdapter, body: GuardarBorradorRequest, solicitud_id:
         ("control_de_piernas", body.control_de_piernas),
         ("padecimiento", body.padecimiento),
         ("soporte_oxigeno", body.soporte_oxigeno),
-        ("observaciones_posturales", body.observaciones_posturales),
         ("entidad_solicitante", body.entidad_solicitante),
         ("prioridad", body.prioridad),
         ("justificacion", body.justificacion),

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -418,7 +418,6 @@ class SolicitudCreateRequest(BaseModel):
     control_de_piernas: str
     padecimiento: Optional[str] = None
     soporte_oxigeno: bool = False
-    observaciones_posturales: Optional[str] = None
     unidad_medida: str = "in"
     altura_total_in: Optional[Decimal] = None
     peso_kg: Optional[Decimal] = None
@@ -554,7 +553,6 @@ class SolicitudUpdateRequest(BaseModel):
     control_de_piernas: Optional[str] = None
     padecimiento: Optional[str] = None
     soporte_oxigeno: Optional[bool] = None
-    observaciones_posturales: Optional[str] = None
     unidad_medida: Optional[str] = None
     altura_total_in: Optional[Decimal] = None
     peso_kg: Optional[Decimal] = None
@@ -1423,7 +1421,7 @@ def crear_solicitud(
             INSERT INTO solicitudes_tecnicas
                 (beneficiario_id, usuario_id, entorno, control_tronco, control_cabeza, control_de_piernas,
                  padecimiento,
-                 soporte_oxigeno, observaciones_posturales, altura_total_in, peso_kg,
+                 soporte_oxigeno, altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura, unidad_peso_captura, foto_url,
                  entidad_solicitante, prioridad, justificacion, status)
@@ -1439,7 +1437,6 @@ def crear_solicitud(
                 body.control_de_piernas,
                 body.padecimiento,
                 body.soporte_oxigeno,
-                body.observaciones_posturales,
                 body.altura_total_in,
                 body.peso_kg,
                 body.medida_cabeza_asiento,
@@ -1492,7 +1489,7 @@ def obtener_solicitud(
     if row is None:
         raise HTTPException(status_code=404, detail="Solicitud no encontrada")
 
-    assert_resource_owner(row["usuario_id"], usuario)
+    assert_resource_owner(row["usuario_id"], usuario, db=db, estudio_id=id)
 
     out = dict(row)
     beneficiario = db.execute(
@@ -1526,7 +1523,7 @@ def actualizar_solicitud(
     if existing is None:
         raise HTTPException(status_code=404, detail="Solicitud no encontrada")
 
-    assert_resource_owner(existing["usuario_id"], usuario)
+    assert_resource_owner(existing["usuario_id"], usuario, db=db, estudio_id=id)
 
     fields = body.model_dump(exclude_none=True)
     # Diagnostico lives on beneficiarios, not solicitudes_tecnicas
@@ -1683,7 +1680,7 @@ def obtener_foto_solicitud(
     if row is None:
         raise HTTPException(status_code=404, detail="Solicitud no encontrada")
 
-    assert_resource_owner(row["usuario_id"], usuario)
+    assert_resource_owner(row["usuario_id"], usuario, db=db, estudio_id=id)
 
     foto_path = extract_foto_path(row.get("foto_path")) or extract_foto_path(row.get("foto_url"))
     if foto_path is None:

--- a/backend/tests/test_tecnica.py
+++ b/backend/tests/test_tecnica.py
@@ -223,6 +223,62 @@ class TestTecnicaRbac:
         )
         assert close_response.status_code == 403
 
+    def test_org_leader_can_read_solicitud(
+        self,
+        client,
+        admin_headers,
+        tecnico_user,
+        tecnico_headers,
+        capturista_user,
+        capturista_headers,
+        sample_estudio,
+    ):
+        """Regression #54: an org leader must read solicitudes técnicas captured
+        under their organization. The endpoint previously called
+        assert_resource_owner without db/estudio_id, so the leader bypass never
+        ran and leaders got 403."""
+        create_response = client.post(
+            "/api/solicitudes",
+            headers=tecnico_headers,
+            json=_solicitud_payload(sample_estudio["beneficiario_id"]),
+        )
+        assert create_response.status_code == 201, create_response.text
+        solicitud_id = create_response.json()["solicitud_id"]
+
+        # Link the org to the capturing account so org-owned solicitudes match
+        # the leader-bypass query (organizaciones.usuario_id == solicitud.usuario_id).
+        org_response = client.post(
+            "/api/organizaciones",
+            headers=admin_headers,
+            json={"nombre": "Rotary Líder Test", "usuario_id": tecnico_user["id"]},
+        )
+        assert org_response.status_code == 201, org_response.text
+        org_id = org_response.json()["id"]
+
+        leader_assign = client.post(
+            f"/api/organizaciones/{org_id}/lider",
+            headers=admin_headers,
+            json={"lider_usuario_id": capturista_user["id"]},
+        )
+        assert leader_assign.status_code == 200
+
+        # Leader bypass: capturista_user leads the org that owns the solicitud → 200
+        leader_response = client.get(
+            f"/api/solicitudes/{solicitud_id}",
+            headers=capturista_headers,
+        )
+        assert leader_response.status_code == 200
+
+        # Boundary: an unrelated user (not owner, not leader, not admin) → 403
+        outsider_headers = _create_user_and_login(
+            client, admin_headers, suffix="outsider", rol="tecnico"
+        )
+        outsider_response = client.get(
+            f"/api/solicitudes/{solicitud_id}",
+            headers=outsider_headers,
+        )
+        assert outsider_response.status_code == 403
+
 
 # ---------------------------------------------------------------------------
 # Phase 5: Measura validation tests (Pydantic model-level, no DB needed)


### PR DESCRIPTION
## Qué resuelve

Cierra **#54**: el líder de organización recibía 403 en `solicitudes técnicas` porque los endpoints `/solicitudes` llamaban a `assert_resource_owner` **sin** `db`/`estudio_id`, así que el bypass de líder (que ya existe en `auth.py`) nunca corría.

Fix: pasar `db` y el `id` de la solicitud en los 3 call sites (`tecnica.py` 1495, 1529, 1686), igual que ya hace `socioeconomico.py`.

## ⚠️ Hallazgo crítico durante la verificación

Al intentar testear #54 con TDD, descubrí que **`POST /solicitudes` y guardar-borrador estaban completamente rotos en esta rama**, por el merge del rename `observaciones_posturales → padecimiento` quedado a medias:

1. **Conteo de placeholders**: el INSERT de `crear_solicitud` tenía 23 columnas y 23 args pero 22 `%s` → rompía la creación en todos lados (`not all arguments converted`).
2. **Columna renombrada-y-eliminada**: el código seguía referenciando `observaciones_posturales` (modelos + INSERT + mappings), columna que el rename eliminó.
3. **Orden columnas↔args desalineado** en el INSERT de `guardar_borrador` (boolean cayendo en columna `real`).

Reparado: saqué `observaciones_posturales` de modelos/INSERTs/mappings en `tecnica.py` y `guardar_borrador.py`, alineé el orden en el borrador, y agregué `ALTER ADD COLUMN padecimiento` en `init_db.py` para que el testschema stale se auto-cure.

## Migración de producción pendiente

`public.solicitudes_tecnicas` en prod **todavía tiene `observaciones_posturales`, no `padecimiento`** — la migración `0013_rename_...` **nunca se aplicó**. Este código asume el nombre nuevo. **La migración 0013 debe aplicarse a prod junto con este deploy** (ver nota de timing en el hilo).

## Tests

- Nuevo test de regresión `test_org_leader_can_read_solicitud`: líder → 200, ajeno → 403.
- `test_guardar_borrador`: 24/24 verde (estaban todos rotos por el placeholder bug).
- Create de técnica + oxígeno: verde.

## Fuera de alcance (rot pre-existente, NO introducido acá)

Verificado con baseline (`git stash`): estos fallan también sin mis cambios, por testschema stale (#59) y tests viejos:
- 4 tests de PATCH a `status:completo` sin medidas (validación de finalización agregada después).
- RBAC: 2 tests asumen que `capturista` no puede crear solicitudes, pero el decorator lo permite — vale revisar como issue aparte.
- `test_imss_infonavit_triestado`, `test_nombre_estructurado`, `test_admin_beneficiarios`.

Closes #54