### PR TITLE
fix(db): least-privilege app_runtime runtime role (#73)

### DIFF
--- a/backend/migrations/0014_app_runtime_role.sql
+++ b/backend/migrations/0014_app_runtime_role.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Migration: 0014_app_runtime_role.sql
+-- Purpose:  Issue #73 — least-privilege runtime role (NOT superuser).
+--           The app connects via a direct psycopg2 connection. Today the
+--           default user is the superuser `postgres`, so any injection, leaked
+--           credential, or authz bug has superuser reach (DROP, total R/W).
+--           This creates a bounded `app_runtime` role: DML only, no DDL,
+--           NOSUPERUSER / NOCREATEDB / NOCREATEROLE / NOBYPASSRLS. Production
+--           DB_USER then points at this role instead of `postgres`.
+--
+-- RLS note: every public table already has RLS ENABLED but NOT FORCED, so the
+--           table owner (`postgres`) silently bypasses it — that is why the app
+--           works today as superuser. `app_runtime` is NOT the owner and is
+--           NOBYPASSRLS, so RLS would otherwise deny it every row. We add a
+--           permissive `app_runtime_all` policy per table: the FastAPI backend
+--           is the trusted authz boundary, while the anon/authenticated
+--           PostgREST roles stay restricted by the 0003 policies.
+--
+-- FOOTGUN:  Any NEW table needs its own `app_runtime_all` policy in the
+--           migration that creates it, or the backend will be denied on it.
+--           DML grants for future tables ARE auto-covered (ALTER DEFAULT
+--           PRIVILEGES below); RLS policies are NOT — they must be added by hand.
+--
+-- Password: NOT committed. After applying, set it out-of-band from a secret:
+--             ALTER ROLE app_runtime WITH PASSWORD '<from-secret-manager>';
+--           then set production env: DB_USER=app_runtime, DB_PASSWORD=<secret>.
+--           (CONNECT on the database is granted to PUBLIC by default on
+--           Supabase; add an explicit GRANT CONNECT if your cluster revokes it.)
+-- ============================================================================
+
+-- 1. Role attributes (idempotent). No password is set here on purpose.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_runtime') THEN
+    CREATE ROLE app_runtime LOGIN
+      NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
+  ELSE
+    ALTER ROLE app_runtime LOGIN
+      NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;
+  END IF;
+END $$;
+
+-- 2. Schema usage — required to reference any object in `public`.
+GRANT USAGE ON SCHEMA public TO app_runtime;
+
+-- 3. DML on all existing tables. No DDL and deliberately NO TRUNCATE
+--    (TRUNCATE can wipe a whole table and is not part of normal app traffic).
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_runtime;
+
+-- 4. Sequences — serial PKs need USAGE+SELECT for nextval()/currval().
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_runtime;
+
+-- 5. Future objects created by `postgres` inherit the same minimal grants.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_runtime;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO app_runtime;
+
+-- 6. Permissive RLS policy per existing table so the NOBYPASSRLS role passes.
+--    The backend is trusted; row-level filtering for it happens in FastAPI.
+DO $$
+DECLARE t text;
+BEGIN
+  FOR t IN
+    SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS app_runtime_all ON public.%I', t);
+    EXECUTE format(
+      'CREATE POLICY app_runtime_all ON public.%I '
+      'FOR ALL TO app_runtime USING (true) WITH CHECK (true)',
+      t
+    );
+  END LOOP;
+END $$;

--- a/backend/tests/test_app_runtime_role_migration.py
+++ b/backend/tests/test_app_runtime_role_migration.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1] / "migrations" / "0014_app_runtime_role.sql"
+)
+
+
+def _sql() -> str:
+    return MIGRATION.read_text(encoding="utf-8").lower()
+
+
+def _statements() -> str:
+    """SQL with `--` comment lines stripped, so assertions ignore prose."""
+    lines = [
+        ln for ln in _sql().splitlines() if not ln.lstrip().startswith("--")
+    ]
+    return "\n".join(lines)
+
+
+def test_role_is_least_privilege_not_superuser() -> None:
+    sql = _sql()
+    assert "create role app_runtime login" in sql
+    for attr in ("nosuperuser", "nocreatedb", "nocreaterole", "nobypassrls"):
+        assert attr in sql, f"missing role attribute: {attr}"
+
+
+def test_grants_dml_only_no_ddl() -> None:
+    sql = _statements()
+    assert "grant select, insert, update, delete on all tables in schema public to app_runtime" in sql
+    assert "grant usage, select on all sequences in schema public to app_runtime" in sql
+    # No blanket / DDL-capable grants reach the runtime role.
+    assert "grant all" not in sql
+    assert "truncate" not in sql  # TRUNCATE is intentionally withheld.
+
+
+def test_permissive_policy_keeps_nobypassrls_role_functional() -> None:
+    sql = _sql()
+    # RLS is already enabled on every table; a permissive policy is required or
+    # the NOBYPASSRLS role would be denied every row.
+    assert "app_runtime_all" in sql
+    assert "for all to app_runtime using (true) with check (true)" in sql
+
+
+def test_future_tables_inherit_grants_via_default_privileges() -> None:
+    sql = _sql()
+    assert "alter default privileges for role postgres in schema public" in sql


### PR DESCRIPTION
Closes #73

## Summary
- Adds migration `0014_app_runtime_role.sql` creating a bounded `app_runtime` Postgres role so the app no longer connects as superuser `postgres`.
- DML-only: `SELECT/INSERT/UPDATE/DELETE` on tables, `USAGE/SELECT` on sequences. No DDL, no `TRUNCATE`. `NOSUPERUSER / NOCREATEDB / NOCREATEROLE / NOBYPASSRLS`.
- Production `DB_USER` now points at `app_runtime` instead of `postgres`.

## Why
Connecting as superuser meant any injection, leaked credential, or authz bug had superuser reach (total R/W, `DROP`, bypass of any future RLS). This caps the blast radius at the DB level — the real security boundary, not just FastAPI.

## RLS note (important)
Every `public` table already had RLS **enabled but not forced**, so the owner (`postgres`) silently bypassed it — that's why the app worked as superuser. A `NOBYPASSRLS` non-owner role would otherwise be denied every row, so the migration adds a permissive `app_runtime_all` policy per table. The FastAPI backend stays the trusted authz boundary; `anon`/`authenticated` PostgREST roles remain restricted by the `0003` policies.

**Footgun:** any NEW table needs its own `app_runtime_all` policy (DML grants for future tables are auto-covered by `ALTER DEFAULT PRIVILEGES`; RLS policies are not). Documented in the migration header.

## Changes
| File | Change |
|------|--------|
| `backend/migrations/0014_app_runtime_role.sql` | New: role + minimal grants + permissive RLS policies + default privileges |
| `backend/tests/test_app_runtime_role_migration.py` | New: static test — DML-only, no DDL/TRUNCATE, role functional under RLS |

## Test plan
- [x] `pytest tests/test_app_runtime_role_migration.py` — 4 passed
- [x] Migration applied to Supabase; verified via `has_table_privilege`: DML ✅ on 16/16 tables, TRUNCATE ❌, schema CREATE ❌, 16/16 policies, 15/15 sequences, future-object default privileges DML-only
- [x] Live prod smoke after cutover: `POST /api/auth/login` returns 401 (not 500) — app connects and reads `usuarios` as `app_runtime`

## Notes for reviewer
- The migration was already applied to the live Supabase DB and prod `DB_USER`/`DB_PASSWORD` were cut over to `app_runtime` (verified). The interim password used during cutover should be rotated.
- Acceptance criteria met: connection is no longer `postgres`/service role; `DROP TABLE` from the app fails by permission (role is not owner, no DDL); full flow works.