### PR TITLE
fix(db): make migration prefixes unique

### DIFF
--- a/backend/migrations/0015_prd_opcion_b_fields.sql
+++ b/backend/migrations/0015_prd_opcion_b_fields.sql
@@ -1,3 +1,5 @@
+-- 0015_prd_opcion_b_fields.sql
+
 ALTER TABLE public.beneficiarios
 ADD COLUMN IF NOT EXISTS num_ext TEXT,
 ADD COLUMN IF NOT EXISTS num_int TEXT,

--- a/backend/migrations/0016_add_unidad_peso_captura.sql
+++ b/backend/migrations/0016_add_unidad_peso_captura.sql
@@ -1,4 +1,4 @@
--- Migration 0008: Add unidad_peso_captura column to solicitudes_tecnicas
+-- Migration 0016: Add unidad_peso_captura column to solicitudes_tecnicas
 -- Feature: Unidades de Peso y Zoom de Imagen
 -- Field technicians can now record weight in pounds (lb) or kilograms (kg).
 -- The DB always stores the canonical kg value; unidad_peso_captura records

--- a/backend/migrations/0017_add_finalizado_at.sql
+++ b/backend/migrations/0017_add_finalizado_at.sql
@@ -1,4 +1,4 @@
--- 0010_add_finalizado_at.sql
+-- 0017_add_finalizado_at.sql
 -- Objetivo:
 --   Agregar columna finalizado_at a estudios_socioeconomicos y solicitudes_tecnicas
 --   para registrar el timestamp de finalización (transición borrador → completo).

--- a/backend/migrations/0018_add_soporte_oxigeno_to_solicitudes_tecnicas.sql
+++ b/backend/migrations/0018_add_soporte_oxigeno_to_solicitudes_tecnicas.sql
@@ -1,2 +1,4 @@
+-- 0018_add_soporte_oxigeno_to_solicitudes_tecnicas.sql
+
 ALTER TABLE public.solicitudes_tecnicas
 ADD COLUMN IF NOT EXISTS soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -9,6 +9,33 @@ Este directorio es la única fuente válida para cambios de esquema.
 3. **Sin big-bang**: cambios aditivos primero (compatibilidad temporal), limpieza después.
 4. **Nombres ordenados**: usar prefijo secuencial (`0001_`, `0002_`, etc.).
 
+## Orden canónico actual
+
+Los prefijos deben ser únicos. Si una migración ya fue aplicada en un entorno
+con un nombre anterior, validar primero el contenido de la tabla de control del
+runner (`supabase_migrations` o equivalente) antes de renombrar el historial en
+ese entorno.
+
+| Prefijo | Migración |
+| --- | --- |
+| `0002` | `add_foto_path_to_solicitudes_tecnicas` |
+| `0003` | `rls_policies` |
+| `0004` | `add_documento_refs_to_estudios_socioeconomicos` |
+| `0005` | `prd_ajustes_nombre_estructurado` |
+| `0006` | `prd_ajustes_imss_infonavit_triestado` |
+| `0007` | `medidas_decimal_7_3` |
+| `0008` | `add_tutor_email` |
+| `0009` | `prevent_duplicate_estudios_solicitudes` |
+| `0010` | `add_avatar_url_to_usuarios` |
+| `0011` | `make_draft_columns_nullable` |
+| `0012` | `organizaciones_membership_voluntarios` |
+| `0013` | `rename_observaciones_posturales_to_padecimiento` |
+| `0014` | `app_runtime_role` |
+| `0015` | `prd_opcion_b_fields` |
+| `0016` | `add_unidad_peso_captura` |
+| `0017` | `add_finalizado_at` |
+| `0018` | `add_soporte_oxigeno_to_solicitudes_tecnicas` |
+
 ## Deprecación de legado
 
 `backend/migrate_v2.sql` queda marcado como **LEGACY / DO NOT EXECUTE**.

--- a/backend/tests/test_migration_deprecation.py
+++ b/backend/tests/test_migration_deprecation.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from pathlib import Path
 
 
@@ -16,3 +17,11 @@ def test_incremental_migrations_readme_exists_with_rule() -> None:
 
     assert "solo migraciones incrementales" in content.lower()
     assert "reversible" in content.lower()
+
+
+def test_incremental_migration_prefixes_are_unique() -> None:
+    migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
+    prefixes = [path.name.split("_", 1)[0] for path in migrations_dir.glob("*.sql")]
+    duplicate_prefixes = [prefix for prefix, count in Counter(prefixes).items() if count > 1]
+
+    assert duplicate_prefixes == []


### PR DESCRIPTION
## Summary
- Renumber duplicate local migration prefixes to the next available sequence values
- Document the canonical migration order in backend/migrations/README.md
- Add a regression test to ensure migration prefixes remain unique

## Verification
- python prefix uniqueness check: OK, 17 migrations with no duplicate prefixes
- py_compile backend/tests/test_migration_deprecation.py
- pytest not run: pytest is not installed in the local environment

Closes #58