### PR TITLE
fix(security): remove admin beneficiary PII debug logs

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -720,12 +720,6 @@ def actualizar_beneficiario_admin(
     values = list(fields.values())
     values.append(beneficiario_id)
 
-    import logging
-    logging.basicConfig(level=logging.DEBUG)
-    logger = logging.getLogger(__name__)
-    logger.debug(f"[ADMIN PATCH] SQL: UPDATE beneficiarios SET {set_clause} WHERE id = %s")
-    logger.debug(f"[ADMIN PATCH] Values: {values}")
-
     db.execute(
         f"UPDATE beneficiarios SET {set_clause} WHERE id = %s",
         values,


### PR DESCRIPTION
## Summary
- Remove DEBUG logging from admin beneficiary PATCH handler that printed SQL and row values.
- Stop per-request logging.basicConfig(DEBUG) reconfiguration from that endpoint.

## Verification
- pytest backend/tests/test_admin_beneficiarios.py::TestAdminPatchBeneficiario
- pytest backend/tests/test_admin_beneficiarios.py (15 passed, 2 failed: existing 404s in solicitud/gestion tests where fixture has solicitud=None)

Closes #50