### PR TITLE
fix(db): backfill ciudad normalization (#67)

### DIFF
--- a/backend/migrations/0015_normalize_ciudad_municipio.sql
+++ b/backend/migrations/0015_normalize_ciudad_municipio.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- Migration: 0015_normalize_ciudad_municipio.sql
+-- Purpose:  Issue #67 — backfill beneficiarios.ciudad to the canonical form
+--           introduced in the frontend normalization PR (#91, issue #67).
+--
+--           The frontend now normalises ciudad on every write:
+--             1. Collapse internal whitespace runs to a single space
+--             2. Trim leading/trailing whitespace
+--             3. Uppercase, accent-preserving (JS toLocaleUpperCase("es-MX"))
+--
+--           Before that PR landed, rows accumulated mixed-case values
+--           (e.g. "Mérida", "MERIDA", "mérida ", "Guadalajara"). The
+--           admin list/export endpoint groups by ciudad, so those variants
+--           produced duplicate buckets in reports.
+--
+--           This UPDATE normalises every existing row to the same canonical
+--           form so that old and new records match when grouped.
+--
+-- SQL vs. JS equivalence:
+--           Postgres upper() is Unicode-aware and preserves accent marks
+--           exactly as JS toLocaleUpperCase("es-MX") does for Spanish
+--           characters (á→Á, é→É, í→Í, ó→Ó, ú→Ú, ñ→Ñ, ü→Ü).
+--           regexp_replace(ciudad, '\s+', ' ', 'g') collapses whitespace
+--           runs to a single space; btrim() removes leading/trailing spaces.
+--           This is a faithful server-side replica of the frontend rule.
+--
+-- Idempotency: the WHERE clause skips rows that are already normalised, so
+--           re-running this migration is safe and produces no spurious writes.
+--
+-- Scope:    Only beneficiarios.ciudad. ciudad_registro and other columns are
+--           NOT touched.
+-- ============================================================================
+
+UPDATE beneficiarios
+SET    ciudad = upper(btrim(regexp_replace(ciudad, '\s+', ' ', 'g')))
+WHERE  ciudad IS NOT NULL
+  AND  ciudad <> upper(btrim(regexp_replace(ciudad, '\s+', ' ', 'g')));


### PR DESCRIPTION
## Contexto

Complemento backend del PR #91 (mergeado), issue #67. El frontend ahora normaliza `beneficiarios.ciudad` al **escribir** (mayúsculas, colapso de espacios, **preservando acentos**). Los registros históricos siguen en su case original, así que el listado/export de admin (`backend/routers/admin.py`, agrupa por `ciudad`) queda con buckets duplicados (`Mérida` vs `MÉRIDA`).

Este PR alinea los datos viejos con la forma canónica nueva mediante una migración de backfill única.

## Cambios

- `backend/migrations/0015_normalize_ciudad_municipio.sql` — `UPDATE` idempotente sobre `beneficiarios.ciudad`.

```sql
UPDATE beneficiarios
SET    ciudad = upper(btrim(regexp_replace(ciudad, '\\s+', ' ', 'g')))
WHERE  ciudad IS NOT NULL
  AND  ciudad <> upper(btrim(regexp_replace(ciudad, '\\s+', ' ', 'g')));
```

## Equivalencia con el frontend

| JS (frontend) | SQL (migración) |
|---|---|
| `toLocaleUpperCase("es-MX")` | `upper()` — Unicode-aware, preserva á/é/í/ó/ú/ñ/ü |
| colapso de espacios `\\s+` → ` ` | `regexp_replace(ciudad, '\\s+', ' ', 'g')` |
| `.trim()` | `btrim()` |

## Notas para revisar más tarde

- ⚠️ **Es un `UPDATE` sobre datos de producción.** Revisar antes de aplicar; correr primero un `SELECT` con la misma expresión para ver cuántas filas cambian.
- **Idempotente:** el `WHERE` salta las filas ya normalizadas; re-ejecutar es seguro.
- **Scope acotado:** solo `beneficiarios.ciudad`. No toca `ciudad_registro` ni otras columnas.
- Las migraciones se aplican manualmente (psycopg2, ver CLAUDE.md); este PR **no** ejecuta nada contra la DB.

Cierra el follow-up de #67.