### PR TITLE
fix(frontend): require soporte de oxigeno selection

### DIFF
--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -257,7 +257,7 @@
                     <span class="ml-2 text-sm font-medium text-slate-700">Sí</span>
                   </label>
                   <label class="inline-flex items-center">
-                    <input class="text-primary focus:ring-primary h-4 w-4" name="soporte_oxigeno" type="radio" value="false" checked />
+                    <input class="text-primary focus:ring-primary h-4 w-4" name="soporte_oxigeno" type="radio" value="false" />
                     <span class="ml-2 text-sm font-medium text-slate-700">No</span>
                   </label>
                 </div>
@@ -1915,6 +1915,12 @@
         const toStrOrNull = (v) => {
           const s = (v || "").trim();
           return s === "" ? null : s;
+        const getRadioBoolOrNull = (name) => {
+          const value = fd.get(name);
+          if (value === "true") return true;
+          if (value === "false") return false;
+          return null;
+        }
         };
 
         return {
@@ -1924,7 +1930,7 @@
           control_cabeza: get("control_cabeza"),
           control_de_piernas: get("control_de_piernas"),
           padecimiento: get("padecimiento") || null,
-          soporte_oxigeno: get("soporte_oxigeno") === "true",
+          soporte_oxigeno: getRadioBoolOrNull("soporte_oxigeno"),,
           observaciones_posturales: get("observaciones_posturales") || null,
           altura_total_in: toStrOrNull(get("altura_total_in")),
           peso_kg: toStrOrNull(get("peso_kg")),
@@ -2106,7 +2112,10 @@
             control_cabeza: tecnicaData.control_cabeza || null,
             control_de_piernas: tecnicaData.control_de_piernas || null,
             padecimiento: tecnicaData.padecimiento || null,
-            soporte_oxigeno: tecnicaData.soporte_oxigeno ?? false,
+            soporte_oxigeno:
+              typeof tecnicaData.soporte_oxigeno === "boolean"
+                ? tecnicaData.soporte_oxigeno
+                : null,
             observaciones_posturales: tecnicaData.observaciones_posturales || null,
             altura_total_in: tecnicaData.altura_total_in || null,
             peso_kg: tecnicaData.peso_kg || null,
@@ -2257,7 +2266,7 @@
           control_cabeza: get("control_cabeza"),
           control_de_piernas: get("control_de_piernas"),
           padecimiento: get("padecimiento"),
-          soporte_oxigeno: get("soporte_oxigeno") === "true",
+          soporte_oxigeno: getRadioBoolOrNull("soporte_oxigeno"),
           observaciones_posturales: get("observaciones_posturales"),
           altura_total_in: toStrOrNull(get("altura_total_in")),
           peso_kg: toStrOrNull(get("peso_kg")),
@@ -2631,6 +2640,15 @@
 
       // CONTINUAR button: validate + save to localStorage + navigate
       document.getElementById("btn-continuar-tecnica")?.addEventListener("click", () => {
+        const soporteOxigeno = document.querySelector('[name="soporte_oxigeno"]:checked');
+        if (!soporteOxigeno) {
+          alert("Debes indicar si requiere soporte para oxígeno.");
+          document
+            .querySelector('[name="soporte_oxigeno"]')
+            ?.closest("fieldset")
+            ?.scrollIntoView({ behavior: "smooth", block: "center" });
+          return;
+        }
         continuarSolicitudTecnica();
       });
 

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -1915,12 +1915,12 @@
         const toStrOrNull = (v) => {
           const s = (v || "").trim();
           return s === "" ? null : s;
+        };
         const getRadioBoolOrNull = (name) => {
           const value = fd.get(name);
           if (value === "true") return true;
           if (value === "false") return false;
           return null;
-        }
         };
 
         return {
@@ -1930,7 +1930,7 @@
           control_cabeza: get("control_cabeza"),
           control_de_piernas: get("control_de_piernas"),
           padecimiento: get("padecimiento") || null,
-          soporte_oxigeno: getRadioBoolOrNull("soporte_oxigeno"),,
+          soporte_oxigeno: getRadioBoolOrNull("soporte_oxigeno"),
           observaciones_posturales: get("observaciones_posturales") || null,
           altura_total_in: toStrOrNull(get("altura_total_in")),
           peso_kg: toStrOrNull(get("peso_kg")),
@@ -2243,6 +2243,12 @@
 
         const fd = new FormData(f);
         const get = (name) => fd.get(name) || "";
+        const getRadioBoolOrNull = (name) => {
+          const value = fd.get(name);
+          if (value === "true") return true;
+          if (value === "false") return false;
+          return null;
+        };
 
         let foto_url = null;
         const fileInput = document.getElementById("file-upload");


### PR DESCRIPTION
Closes #70

Replaces #100 because the original branch name contained an accent that made it confusing in GitHub UI.

## Type
- [x] Bug fix

## Summary
- Removes the preselected `No` option from `soporte_oxigeno`.
- Preserves an unanswered state as `null` instead of silently sending `false`.
- Blocks continuing from the technical form until the oxygen support question is answered.

## Changes
| File | Change |
|------|--------|
| `front/Capturista-view/tecnica.html` | Updates oxygen support radio handling and required-selection guard. |

## Test Plan
- [x] Ran `node --check` against the inline JavaScript extracted from `front/Capturista-view/tecnica.html`.
- [x] Verified the PR diff against `branch-beta03` is limited to the technical form.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] No shell scripts changed.
- [x] Docs not required for this frontend bug fix.
- [x] Conventional commit format included for the repair commit.
- [x] No `Co-Authored-By` trailers.