### PR TITLE
Restaurar correctamente el estado de "¿Cómo la obtuvo?" al recargar datos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,9 @@ backend/server.log
 .atl/
 .claude/
 
-# FIXES and PRD documentation (local audit docs, not for repo)
+# FIXES, ISSUES and PRD documentation (local audit docs, not for repo)
 FIXES_*.md
 PRD_*.md
 FIX_*.md
+ISSUES_*.md
+issues/

--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -1264,6 +1264,11 @@
             };
             setVal("silla_previa", data.silla_previa);
             setVal("como_obtuvo_silla", data.como_obtuvo_silla);
+            // setVal asigna .value sin disparar "change", así que re-sincronizamos
+            // el estado habilitado/deshabilitado de "¿Cómo la obtuvo?" según el
+            // valor restaurado de silla_previa (issue #120).
+            const sillaPreviaEl = document.querySelector('[name="silla_previa"]');
+            if (sillaPreviaEl) sillaPreviaEl.dispatchEvent(new Event("change"));
             setVal("fecha_estudio", data.fecha_estudio);
             setVal("entidad_solicitante", data.entidad_solicitante);
             if (data.prioridad) {


### PR DESCRIPTION
Resuelto: Sincronizar correctamente el estado habilitado/deshabilitado del campo dependiente como_obtuvo_silla ("¿Cómo la obtuvo?") cuando se restaura el valor de silla_previa ("¿El beneficiario ha tenido silla previamente?") durante la carga del formulario de Gestión. Revisar issue #120 