### PR TITLE
Deshabilitar el cambio de status (completo ⇄ borrador) desde el panel de administrador

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -8,7 +8,7 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, field_validator, model_validator, ValidationInfo
+from pydantic import BaseModel, field_validator, ValidationInfo
 from decimal import Decimal
 
 from database import get_db, _DBAdapter
@@ -45,7 +45,6 @@ from validators import (
     validate_control_de_piernas,
     validate_unidad_medida,
     validate_unidad_peso,
-    validate_status,
 )
 
 from utils.text import normalize_text
@@ -197,21 +196,18 @@ class AdminBeneficiarioUpdateRequest(BaseModel):
 
 
 class AdminEstudioUpdateRequest(BaseModel):
-    """Admin edit of estudio fields (no owner check)."""
+    """Admin edit of estudio fields (no owner check).
+
+    Issue #106: el admin NO puede mutar `status` (completo <-> borrador). El
+    campo se omite deliberadamente; al usar `extra="ignore"` (default de
+    Pydantic) un `status` enviado por un cliente legado se descarta en silencio.
+    """
     tuvo_silla_previa: Optional[bool] = None
     como_obtuvo_silla: Optional[str] = None
     fecha_estudio: Optional[str] = None
     sede: Optional[str] = None
     ciudad_registro: Optional[str] = None
-    status: Optional[str] = None
     elaboro_estudio: Optional[str] = None
-
-    @field_validator("status")
-    @classmethod
-    def _status_valido(cls, v: Optional[str]) -> Optional[str]:
-        if v is None or v == "":
-            return v
-        return validate_status(v)
 
     @field_validator("como_obtuvo_silla", "ciudad_registro", mode="before")
     @classmethod
@@ -219,17 +215,6 @@ class AdminEstudioUpdateRequest(BaseModel):
         if v is None or v == "":
             return v
         return normalize_text(v)
-
-    @model_validator(mode="after")
-    def _validar_fecha_estudio_completo(self):
-        if self.status == "completo":
-            if not self.fecha_estudio:
-                raise ValueError("fecha_estudio es obligatorio cuando status es completo")
-            if self.tuvo_silla_previa is None:
-                raise ValueError("tuvo_silla_previa es obligatorio cuando status es completo")
-            if self.tuvo_silla_previa is True and (self.como_obtuvo_silla is None or self.como_obtuvo_silla == ""):
-                raise ValueError("como_obtuvo_silla es obligatorio cuando tuvo_silla_previa es verdadero")
-        return self
 
 
 class AdminSolicitudUpdateRequest(BaseModel):
@@ -251,7 +236,7 @@ class AdminSolicitudUpdateRequest(BaseModel):
     entidad_solicitante: Optional[str] = None
     prioridad: Optional[str] = None
     justificacion: Optional[str] = None
-    status: Optional[str] = None
+    # Issue #106: `status` se omite — el admin no puede revertir completo->borrador.
 
     @field_validator("entorno")
     @classmethod
@@ -332,13 +317,6 @@ class AdminSolicitudUpdateRequest(BaseModel):
             return None
         return validate_justificacion(str(v))
 
-    @field_validator("status")
-    @classmethod
-    def _status_valido(cls, v: Optional[str]) -> Optional[str]:
-        if v is None or v == "":
-            return v
-        return validate_status(v)
-
 
 class AdminGestionUpdateRequest(BaseModel):
     """Atomic update of estudio + solicitud in one transaction."""
@@ -349,7 +327,7 @@ class AdminGestionUpdateRequest(BaseModel):
     sede: Optional[str] = None
     ciudad_registro: Optional[str] = None
     elaboro_estudio: Optional[str] = None
-    status_estudio: Optional[str] = None
+    # Issue #106: `status_estudio` se omite — el admin no puede mutar el status.
     # Solicitud fields
     entidad_solicitante: Optional[str] = None
     prioridad: Optional[str] = None
@@ -361,13 +339,6 @@ class AdminGestionUpdateRequest(BaseModel):
         if v is None or v == "":
             return v
         return normalize_text(v)
-
-    @field_validator("status_estudio")
-    @classmethod
-    def _status_valido(cls, v: Optional[str]) -> Optional[str]:
-        if v is None or v == "":
-            return v
-        return validate_status(v)
 
     @field_validator("entidad_solicitante", mode="before")
     @classmethod
@@ -389,17 +360,6 @@ class AdminGestionUpdateRequest(BaseModel):
         if v is None or (isinstance(v, str) and v.strip() == ""):
             return None
         return validate_justificacion(str(v))
-
-    @model_validator(mode="after")
-    def _validar_estudio_completo(self):
-        if self.status_estudio == "completo":
-            if not self.fecha_estudio:
-                raise ValueError("fecha_estudio es obligatorio cuando status es completo")
-            if self.tuvo_silla_previa is None:
-                raise ValueError("tuvo_silla_previa es obligatorio cuando status es completo")
-            if self.tuvo_silla_previa is True and (self.como_obtuvo_silla is None or self.como_obtuvo_silla == ""):
-                raise ValueError("como_obtuvo_silla es obligatorio cuando tuvo_silla_previa es verdadero")
-        return self
 
 
 # ---------------------------------------------------------------------------
@@ -828,9 +788,7 @@ def actualizar_gestion_admin(
         if val is not None:
             estudio_fields[key] = val
 
-    # status_estudio mapped to estudio's status
-    if body.status_estudio is not None:
-        estudio_fields["status"] = body.status_estudio
+    # Issue #106: el admin no puede mutar el status del estudio desde /gestion.
 
     if "tuvo_silla_previa" in estudio_fields:
         estudio_fields["tuvo_silla_previa"] = int(estudio_fields["tuvo_silla_previa"])

--- a/backend/tests/test_admin_unit.py
+++ b/backend/tests/test_admin_unit.py
@@ -206,56 +206,39 @@ class TestAdminEstudioUpdateRequest:
         body = AdminEstudioUpdateRequest()
         assert body.model_dump(exclude_none=True) == {}
 
-    def test_status_valid(self):
-        """Valid status passes (model_validator requires fecha_estudio when completo)."""
-        body = AdminEstudioUpdateRequest(status="borrador")
-        assert body.status == "borrador"
-
-    def test_status_completo_requires_fecha(self):
-        """status=completo requires fecha_estudio due to model_validator."""
-        with pytest.raises(ValueError, match="fecha_estudio es obligatorio cuando status es completo"):
-            AdminEstudioUpdateRequest(status="completo")
-
-    def test_status_invalid(self):
-        """Invalid status raises ValueError."""
-        with pytest.raises(ValueError, match="status fuera de catálogo"):
-            AdminEstudioUpdateRequest(status="invalido")
+    def test_status_is_ignored(self):
+        """Issue #106: el admin no puede mutar `status`. El campo ya no existe
+        en el modelo y un `status` enviado por un cliente legado se descarta.
+        """
+        body = AdminEstudioUpdateRequest(status="completo")
+        assert "status" not in body.model_dump(exclude_none=True)
+        assert not hasattr(body, "status")
+        assert "status" not in AdminEstudioUpdateRequest.model_fields
 
     def test_fecha_estudio_no_validator_in_model(self):
         """fecha_estudio has no field_validator in AdminEstudioUpdateRequest
         (validation happens at router level via validate_fecha_estudio).
         """
-        body = AdminEstudioUpdateRequest(fecha_estudio="15-01-2026", status="borrador")
+        body = AdminEstudioUpdateRequest(fecha_estudio="15-01-2026")
         assert body.fecha_estudio == "15-01-2026"  # no validation in model
 
-    def test_tuvo_silla_previa_requires_como_obtuvo(self):
-        """If status=completo and tuvo_silla_previa=True, como_obtuvo_silla is required."""
-        with pytest.raises(ValueError, match="como_obtuvo_silla es obligatorio"):
-            AdminEstudioUpdateRequest(
-                status="completo",
-                tuvo_silla_previa=True,
-                fecha_estudio="2026-01-15",
-            )
-
     def test_tuvo_silla_previa_valid(self):
-        """tuvo_silla_previa=False with status=completo passes."""
+        """tuvo_silla_previa is accepted without status coupling (Issue #106)."""
         body = AdminEstudioUpdateRequest(
-            status="completo",
             tuvo_silla_previa=False,
             fecha_estudio="2026-01-15",
         )
         assert body.tuvo_silla_previa is False
 
-    def test_como_obtuvo_silla_no_validator_when_borrador(self):
-        """como_obtuvo_silla is NOT validated when status != completo.
-        The catalog validation only happens in the router endpoint via _resolve_como_obtuvo_silla.
+    def test_como_obtuvo_silla_no_validator_in_model(self):
+        """como_obtuvo_silla catalog validation only happens in the router endpoint
+        via _resolve_como_obtuvo_silla, not in the model.
         """
         body = AdminEstudioUpdateRequest(
             tuvo_silla_previa=True,
             como_obtuvo_silla="ROBADA",
-            status="borrador",
         )
-        assert body.como_obtuvo_silla == "ROBADA"  # no validation in model when borrador
+        assert body.como_obtuvo_silla == "ROBADA"  # no validation in model
 
 
 # ---------------------------------------------------------------------------
@@ -407,10 +390,14 @@ class TestAdminGestionUpdateRequest:
         with pytest.raises(ValueError, match="prioridad fuera de catálogo"):
             AdminGestionUpdateRequest(prioridad="Baja")
 
-    def test_status_estudio_invalid(self):
-        """Invalid status_estudio raises ValueError (validate_status uses 'status' as field name)."""
-        with pytest.raises(ValueError, match="status fuera de catálogo"):
-            AdminGestionUpdateRequest(status_estudio="rechazado")
+    def test_status_estudio_is_ignored(self):
+        """Issue #106: el admin no puede mutar el status del estudio desde /gestion.
+        `status_estudio` ya no existe en el modelo y se descarta si se envía.
+        """
+        body = AdminGestionUpdateRequest(status_estudio="completo")
+        assert "status_estudio" not in body.model_dump(exclude_none=True)
+        assert not hasattr(body, "status_estudio")
+        assert "status_estudio" not in AdminGestionUpdateRequest.model_fields
 
 
 # ---------------------------------------------------------------------------

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -980,7 +980,7 @@
               _fd("Tuvo silla previa", e.tuvo_silla_previa != null ? (e.tuvo_silla_previa ? "Sí" : "No") : null) +
               _fd("Cómo obtuvo silla", e.como_obtuvo_silla) +
               _fd("Elaboró estudio", e.elaboro_estudio) +
-              _fd("Status", e.status) +
+              _fd("Status", _statusLabel(e.status)) +
             '</div>') +
           // 6. Datos Técnicos — Controles
           _sec("Datos Técnicos — Controles",
@@ -999,7 +999,7 @@
               _fd("Entidad solicitante", s.entidad_solicitante) +
               _fd("Prioridad", s.prioridad) +
               _fd("Justificación", s.justificacion) +
-              _fd("Status técnico", s.status) +
+              _fd("Status técnico", _statusLabel(s.status)) +
             '</div>') +
           // 9. Fotografía
           _sec("Fotografía Técnica",
@@ -1446,7 +1446,8 @@
           _field("ciudad_registro", "Ciudad de Registro", "text", { maxlength: 80, required: true }) +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">¿Tuvo silla previa?</label><select id="field-tuvo_silla_previa" name="tuvo_silla_previa" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3"><option value="false" ' + (draft.tuvo_silla_previa === "false" ? "selected" : "") + '>No</option><option value="true" ' + (draft.tuvo_silla_previa === "true" ? "selected" : "") + '>Sí</option></select></div>' +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Cómo obtuvo silla</label><select id="field-como_obtuvo_silla" name="como_obtuvo_silla" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3"><option value="">Selecciona una opción</option><option value="COMPRA">Compra</option><option value="DONACION">Donación</option></select></div>' +
-          '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Status</label><select id="field-status" name="status" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3"><option value="borrador">Borrador</option><option value="completo">Completo</option></select></div>' +
+          // Issue #106: status es solo lectura — el admin no puede revertir completo->borrador.
+          _fieldReadonly("Status", _statusLabel(draft.status) || "—") +
           '</div>';
       }
 
@@ -1471,13 +1472,8 @@
             ${_field("medida_rodilla_talon", "Rodilla-Talón (in)", "text", { pattern: "[0-9]+(\\\\.[0-9]{1,3})?" })}
             ${_field("medida_ancho_cadera", "Ancho Cadera (in)", "text", { pattern: "[0-9]+(\\\\.[0-9]{1,3})?" })}
             ${_fieldArea("padecimiento", "Observaciones Posturales", { maxlength: 500 })}
-            <div class="space-y-1 col-span-2">
-              <label class="text-xs font-semibold text-slate-500">Status</label>
-              <select id="field-status-tecnica" name="status" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3">
-                <option value="borrador">Borrador</option>
-                <option value="completo">Completo</option>
-              </select>
-            </div>
+            <!-- Issue #106: status es solo lectura — el admin no puede revertir completo->borrador. -->
+            <div class="col-span-2">${_fieldReadonly("Status", _statusLabel(draft.status) || "—")}</div>
           </div>`;
       }
 
@@ -1488,7 +1484,7 @@
           <div class="grid grid-cols-2 gap-3 mb-4 bg-slate-50 rounded-xl p-4">
             ${_fieldReadonly("Sede", draft.sede_ro)}
             ${_fieldReadonly("Fecha Estudio", draft.fecha_estudio_ro)}
-            ${_fieldReadonly("Status", draft.status_estudio || "—")}
+            ${_fieldReadonly("Status", _statusLabel(draft.status_estudio) || "—")}
           </div>
           <h3 class="text-sm font-bold text-slate-700 mb-3">Gestión de Donación</h3>
           <div class="grid grid-cols-2 gap-3">
@@ -1520,6 +1516,12 @@
       }
       function _fieldReadonly(label, value) {
         return `<div><span class="text-xs text-slate-400">${label}</span><p class="text-sm font-medium text-slate-700">${_escapeHtml(value)}</p></div>`;
+      }
+
+      // Issue #106: muestra el status con la primera letra en mayúscula (Borrador / Completo).
+      function _statusLabel(value) {
+        if (!value) return value;
+        return String(value).charAt(0).toUpperCase() + String(value).slice(1);
       }
 
       function _populateFields(draft) {
@@ -2081,7 +2083,8 @@
       function _extractEstudioPayload(draft, original) {
         original = original || {};
         const fields = {};
-        const keys = ["sede", "fecha_estudio", "ciudad_registro", "status"];
+        // Issue #106: `status` se excluye — el admin no puede mutar el estado del estudio.
+        const keys = ["sede", "fecha_estudio", "ciudad_registro"];
         keys.forEach(function (k) {
           var hasValue = draft[k] !== undefined && draft[k] !== "";
           var wasEmpty = !original[k] || original[k] === "";
@@ -2233,11 +2236,12 @@
       function _extractSolicitudPayload(draft, original) {
         original = original || {};
         const fields = {};
+        // Issue #106: `status` se excluye — el admin no puede mutar el estado de la solicitud.
         const keys = ["entorno", "control_tronco", "control_cabeza", "control_de_piernas",
                        "padecimiento", "altura_total_in", "peso_kg",
                        "medida_cabeza_asiento", "medida_hombro_asiento", "medida_prof_asiento",
                        "medida_rodilla_talon", "medida_ancho_cadera",
-                       "unidad_medida", "unidad_peso_captura", "status"];
+                       "unidad_medida", "unidad_peso_captura"];
         keys.forEach(function (k) {
           var hasValue = draft[k] !== undefined && draft[k] !== "";
           var wasEmpty = !original[k] || original[k] === "";


### PR DESCRIPTION
Se deshabilitó la modificación de `status` desde el panel de administración mediante cambios tanto en frontend como en backend (defensa en profundidad), sin alterar el esquema de base de datos ni el flujo de borradores utilizado por los capturistas.

La columna `status` permanece intacta y los endpoints utilizados por los capturistas para guardar borradores y finalizar registros continúan funcionando sin modificaciones.

Revisar issue #106 