### PR TITLE
Preservar elaboro_estudio al editar como admin (no sobrescribir con "Admin")

### DIFF
--- a/backend/routers/socioeconomico.py
+++ b/backend/routers/socioeconomico.py
@@ -968,10 +968,15 @@ def actualizar_estudio(
             _insertar_tutores(db, existing["beneficiario_id"], tutores_a_insertar)
 
     fields = body.model_dump(exclude_none=True, exclude={"tutores", "elaboro_estudio", "ciudad_registro", "beneficiario"})
-    # Conditional elaboro_estudio: org users can provide their own value
+    # Conditional elaboro_estudio (autoría del estudio):
+    # - org users can provide their own value (nombre del voluntario);
+    # - el dueño (capturista) fija su propio nombre;
+    # - un editor que NO es el dueño (admin / líder de organización sobre un
+    #   registro ajeno) NO debe pisar la autoría: se omite el campo del UPDATE.
+    is_owner = existing["usuario_id"] == usuario.usuario_id
     if usuario.rol == "organizacion" and body.elaboro_estudio:
         fields["elaboro_estudio"] = normalize_text(body.elaboro_estudio)[:120]
-    else:
+    elif is_owner:
         fields["elaboro_estudio"] = usuario.nombre
     if "tuvo_silla_previa" in fields:
         fields["tuvo_silla_previa"] = int(fields["tuvo_silla_previa"])

--- a/backend/tests/test_socioeconomico.py
+++ b/backend/tests/test_socioeconomico.py
@@ -365,6 +365,51 @@ class TestSocioeconomicoRbac:
         assert get_response.status_code == 200
         assert get_response.json()["id"] == estudio_id
 
+    def test_admin_patch_preserves_elaboro_estudio(self, client, admin_headers, capturista_headers, region_lon):
+        """Issue #107: el admin editando un estudio ajeno no debe pisar la autoría
+        (`elaboro_estudio`) con su propio nombre."""
+        create_response = client.post(
+            "/api/estudios",
+            headers=capturista_headers,
+            json=_estudio_payload(region_lon["id"]),
+        )
+        assert create_response.status_code == 201
+        estudio_id = create_response.json()["estudio_id"]
+
+        # El capturista dueño dejó la autoría como "Capturista Test"
+        before = client.get(f"/api/estudios/{estudio_id}", headers=admin_headers).json()
+        assert before["elaboro_estudio"] == "Capturista Test"
+
+        # El admin edita un campo cualquiera sin enviar elaboro_estudio
+        patch_response = client.patch(
+            f"/api/estudios/{estudio_id}",
+            headers=admin_headers,
+            json={"monto_otras_fuentes": 1500},
+        )
+        assert patch_response.status_code == 200
+
+        after = client.get(f"/api/estudios/{estudio_id}", headers=admin_headers).json()
+        assert after["elaboro_estudio"] == "Capturista Test"
+
+    def test_owner_patch_sets_own_name_as_elaboro_estudio(self, client, capturista_headers, region_lon):
+        """El dueño (capturista) sí fija su propio nombre en `elaboro_estudio` al
+        editar su estudio (contrato existente, sin cambios)."""
+        payload = _estudio_payload(region_lon["id"])
+        payload["estudio"]["elaboro_estudio"] = "VALOR VIEJO"
+        create_response = client.post("/api/estudios", headers=capturista_headers, json=payload)
+        assert create_response.status_code == 201
+        estudio_id = create_response.json()["estudio_id"]
+
+        patch_response = client.patch(
+            f"/api/estudios/{estudio_id}",
+            headers=capturista_headers,
+            json={"monto_otras_fuentes": 1500},
+        )
+        assert patch_response.status_code == 200
+
+        after = client.get(f"/api/estudios/{estudio_id}", headers=capturista_headers).json()
+        assert after["elaboro_estudio"] == "Capturista Test"
+
 
 class TestSocioeconomicoMonetaryContract:
     def test_post_persists_clean_numeric_monetary_fields(self, client, capturista_headers, region_lon):


### PR DESCRIPTION
Condicionar la asignación de elaboro_estudio a la propiedad real del recurso.

El handler ya conoce al propietario mediante existing["usuario_id"], utilizado previamente por assert_resource_owner. Con este ajuste:

- El propietario sigue registrando su propio nombre.
- Una cuenta organizacion puede seguir enviando el nombre del voluntario.
- Un editor que no sea el propietario (admin o líder de organización sobre registros ajenos) no modifica la autoría existente.
- No se realizaron cambios de esquema.

Revisar issue #107 