### PR TITLE
Remove dead historial_estados table from cleanup assumptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ backend/server.log
 # FIXES and PRD documentation (local audit docs, not for repo)
 FIXES_*.md
 PRD_*.md
+FIX_*.md

--- a/backend/tests/test_cleanup_scope.py
+++ b/backend/tests/test_cleanup_scope.py
@@ -27,9 +27,17 @@ from conftest import (
 class TestTablesOrder:
     """Verify _TABLES_ORDER is in correct dependency order (children first)."""
 
-    def test_organizaciones_lideres_is_first(self) -> None:
-        """organizaciones_lideres should be first — child of organizaciones/usuarios."""
+    def test_dead_historial_estados_not_in_cleanup(self) -> None:
+        """historial_estados is a dead table (no runtime use, no DDL/migration);
+        it must NOT appear in the cleanup ordering. See issue #116."""
+        assert "historial_estados" not in _TABLES_ORDER
+
+    def test_first_table_is_a_leaf_child(self) -> None:
+        """The first table to clean must be a leaf child — organizaciones_lideres
+        (FK to organizaciones/usuarios), deleted before its parents."""
         assert _TABLES_ORDER[0] == "organizaciones_lideres"
+        assert _TABLES_ORDER.index("organizaciones_lideres") < _TABLES_ORDER.index("organizaciones")
+        assert _TABLES_ORDER.index("organizaciones_lideres") < _TABLES_ORDER.index("usuarios")
 
     def test_beneficiarios_before_paises(self) -> None:
         """beneficiarios must be deleted before paises (FK via regiones)."""


### PR DESCRIPTION
### Cambios

Nota: revisar issue #116 

#### `backend/tests/conftest.py`

- Eliminado `"historial_estados"` de `_TABLES_ORDER`. La lista alimenta `_qualified_table_names()`, usada en los dos `TRUNCATE TABLE` (arranque de sesión y `clean_db`) y en el `DELETE` de `_scoped_cleanup`; todos dejan de referenciar la tabla muerta. No se requieren más cambios porque la tabla nunca se sembraba.
- El primer elemento pasa a ser `organizaciones_lideres` (hoja real, FK a `organizaciones`/`usuarios`), preservando el orden FK-safe (hijos antes que padres).

#### `backend/tests/test_cleanup_scope.py`

- `test_historial_estados_is_first` → reemplazado por:
  - `test_dead_historial_estados_not_in_cleanup`: afirma que `historial_estados` **NO** está en `_TABLES_ORDER` (guard de regresión).
  - `test_first_table_is_a_leaf_child`: afirma que el primer elemento es `organizaciones_lideres` y que precede a sus padres.
- `test_qualified_table_names_when_schema_enabled`: actualizado el primer elemento esperado a `test_suite.organizaciones_lideres`.

#### Sin cambios (intencional)

- `backend/tests/test_app_runtime_role_migration.py:55` ya afirma que `historial_estados` **no** aparece en la migración RLS — guard que refuerza la conclusión de "tabla muerta". Se conserva.
- `CLAUDE.md` y `PRD.md` siguen documentando la tabla como deuda muerta conocida.