### PR TITLE
design: sistema visual unificado (Fases 0–4)

### DIFF
--- a/front/Admin-view/admin-regiones.html
+++ b/front/Admin-view/admin-regiones.html
@@ -232,10 +232,13 @@
             <p id="error-region"   class="hidden text-red-600 text-sm bg-red-50 border border-red-200 rounded-lg px-4 py-2" role="alert"></p>
             <p id="success-region" class="hidden text-green-700 text-sm bg-green-50 border border-green-200 rounded-lg px-4 py-2" role="status"></p>
             <button type="submit" id="btn-region"
-              class="btn-primary w-full py-3 rounded-xl flex items-center justify-center gap-2 disabled:opacity-60 text-sm">
+              class="btn-primary w-full py-3 rounded-xl flex items-center justify-center gap-2 disabled:opacity-60 disabled:cursor-not-allowed text-sm">
               <span class="material-symbols-outlined text-lg">add</span>
               <span id="btn-region-text">Agregar Región</span>
             </button>
+            <p id="region-hint" class="hidden text-xs text-slate-400 text-center mt-2 flex items-center justify-center gap-1">
+              <span class="material-symbols-outlined text-sm">info</span>Selecciona un país primero
+            </p>
           </form>
         </div>
 
@@ -782,7 +785,13 @@
   (function () {
     const sel = document.getElementById('region-pais');
     const btn = document.getElementById('btn-region');
-    function updateBtn() { btn.disabled = !sel.value; }
+    const hint = document.getElementById('region-hint');
+    function updateBtn() {
+      const noPais = !sel.value;
+      btn.disabled = noPais;
+      btn.title = noPais ? 'Selecciona un país primero' : '';
+      if (hint) hint.classList.toggle('hidden', !noPais);
+    }
     sel.addEventListener('change', updateBtn);
     updateBtn();
   })();

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -629,33 +629,33 @@
               ${u.rol === 'organizacion' && u.activo
                 ? `<button onclick="gestionarOrganizacion(${u.usuario_id})"
                   class="btn-icon hover:bg-purple-50 hover:text-primary hover:border-primary/30"
-                  title="Gestionar organización">
-                  <span class="material-symbols-outlined">settings</span>
+                  title="Gestionar organización" aria-label="Gestionar organización">
+                  <span class="material-symbols-outlined" aria-hidden="true">settings</span>
                 </button>`
                 : ''
               }
               <button onclick="openEditUser(${u.usuario_id}, ${JSON.stringify(u.nombre)}, ${JSON.stringify(u.email)}, ${JSON.stringify(u.rol)})"
                 class="btn-icon hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200"
-                title="Editar usuario">
-                <span class="material-symbols-outlined">edit</span>
+                title="Editar usuario" aria-label="Editar usuario">
+                <span class="material-symbols-outlined" aria-hidden="true">edit</span>
               </button>
               ${
                 u.activo
                   ? `<button onclick="deactivateUsuario(${u.usuario_id})"
                 class="btn-icon hover:bg-amber-50 hover:text-amber-700 hover:border-amber-200"
-                title="Desactivar usuario">
-                <span class="material-symbols-outlined">person_off</span>
+                title="Desactivar usuario" aria-label="Desactivar usuario">
+                <span class="material-symbols-outlined" aria-hidden="true">person_off</span>
               </button>`
                   : `<button onclick="reactivateUsuario(${u.usuario_id})"
                 class="btn-icon hover:bg-green-50 hover:text-green-700 hover:border-green-200"
-                title="Reactivar usuario">
-                <span class="material-symbols-outlined">person_check</span>
+                title="Reactivar usuario" aria-label="Reactivar usuario">
+                <span class="material-symbols-outlined" aria-hidden="true">person_check</span>
               </button>`
               }
               <button onclick="hardDeleteUsuario(${u.usuario_id}, ${JSON.stringify(u.nombre)})"
                 class="btn-icon hover:bg-red-50 hover:text-red-600 hover:border-red-200"
-                title="Eliminar permanentemente">
-                <span class="material-symbols-outlined">delete_forever</span>
+                title="Eliminar permanentemente" aria-label="Eliminar usuario permanentemente">
+                <span class="material-symbols-outlined" aria-hidden="true">delete_forever</span>
               </button>
             </div>
           </td>

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -628,34 +628,34 @@
             <div class="flex items-center justify-end gap-1">
               ${u.rol === 'organizacion' && u.activo
                 ? `<button onclick="gestionarOrganizacion(${u.usuario_id})"
-                  class="w-9 h-9 rounded-xl border border-primary/10 text-primary hover:bg-purple-50 hover:border-primary/20 transition-all inline-flex items-center justify-center"
+                  class="btn-icon hover:bg-purple-50 hover:text-primary hover:border-primary/30"
                   title="Gestionar organización">
-                  <span class="material-symbols-outlined text-xl">settings</span>
+                  <span class="material-symbols-outlined">settings</span>
                 </button>`
                 : ''
               }
               <button onclick="openEditUser(${u.usuario_id}, ${JSON.stringify(u.nombre)}, ${JSON.stringify(u.email)}, ${JSON.stringify(u.rol)})"
-                class="w-9 h-9 rounded-xl border border-slate-200 text-slate-500 hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200 transition-all inline-flex items-center justify-center"
+                class="btn-icon hover:bg-blue-50 hover:text-blue-600 hover:border-blue-200"
                 title="Editar usuario">
-                <span class="material-symbols-outlined text-xl">edit</span>
+                <span class="material-symbols-outlined">edit</span>
               </button>
               ${
                 u.activo
                   ? `<button onclick="deactivateUsuario(${u.usuario_id})"
-                class="w-9 h-9 rounded-xl border border-amber-100 text-amber-500 hover:bg-amber-50 hover:text-amber-700 hover:border-amber-200 transition-all inline-flex items-center justify-center"
+                class="btn-icon hover:bg-amber-50 hover:text-amber-700 hover:border-amber-200"
                 title="Desactivar usuario">
-                <span class="material-symbols-outlined text-xl">person_off</span>
+                <span class="material-symbols-outlined">person_off</span>
               </button>`
                   : `<button onclick="reactivateUsuario(${u.usuario_id})"
-                class="w-9 h-9 rounded-xl border border-green-100 text-green-500 hover:bg-green-50 hover:text-green-700 hover:border-green-200 transition-all inline-flex items-center justify-center"
+                class="btn-icon hover:bg-green-50 hover:text-green-700 hover:border-green-200"
                 title="Reactivar usuario">
-                <span class="material-symbols-outlined text-xl">person_check</span>
+                <span class="material-symbols-outlined">person_check</span>
               </button>`
               }
               <button onclick="hardDeleteUsuario(${u.usuario_id}, ${JSON.stringify(u.nombre)})"
-                class="w-9 h-9 rounded-xl border border-red-100 text-red-400 hover:bg-red-50 hover:text-red-600 hover:border-red-200 transition-all inline-flex items-center justify-center"
+                class="btn-icon hover:bg-red-50 hover:text-red-600 hover:border-red-200"
                 title="Eliminar permanentemente">
-                <span class="material-symbols-outlined text-xl">delete_forever</span>
+                <span class="material-symbols-outlined">delete_forever</span>
               </button>
             </div>
           </td>
@@ -1158,47 +1158,24 @@
       }
 
       function _rolBadge(rol) {
+        // Fixed category scale (system tokens only): roles stay distinguishable
+        // but share one component and harmonized visual weight.
         const map = {
-          admin: {
-            cls: "text-purple-700 border border-purple-200",
-            bg: "#F3EEF9",
-            icon: "shield_person",
-            label: "Admin",
-          },
-          capturista: {
-            cls: "text-orange-700 border border-orange-200",
-            bg: "#FFF1EB",
-            icon: "edit_note",
-            label: "Capturista",
-          },
-          tecnico: {
-            cls: "text-teal-700 border border-teal-200",
-            bg: "#EDFAF8",
-            icon: "build",
-            label: "Técnico",
-          },
-          organizacion: {
-            cls: "text-amber-700 border border-amber-200",
-            bg: "#FFFBEB",
-            icon: "groups",
-            label: "Organización",
-          },
+          admin:        { variant: "badge--role",    icon: "shield_person", label: "Admin" },
+          capturista:   { variant: "badge--brand",   icon: "edit_note",     label: "Capturista" },
+          tecnico:      { variant: "badge--info",     icon: "build",         label: "Técnico" },
+          organizacion: { variant: "badge--warning", icon: "groups",        label: "Organización" },
         };
-        const m = map[rol] || {
-          cls: "text-slate-600 border border-slate-200",
-          bg: "#F8FAFC",
-          icon: "person",
-          label: rol || "—",
-        };
-        return `<span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold ${m.cls}" style="background:${m.bg};">
-      <span class="material-symbols-outlined" style="font-size:13px">${m.icon}</span>${_esc(m.label)}
+        const m = map[rol] || { variant: "badge--neutral", icon: "person", label: rol || "—" };
+        return `<span class="badge ${m.variant}">
+      <span class="material-symbols-outlined">${m.icon}</span>${_esc(m.label)}
     </span>`;
       }
 
       function _estadoBadge(activo) {
         return activo
-          ? '<span class="inline-flex items-center gap-1.5 text-xs font-semibold text-green-700"><span class="w-2 h-2 rounded-full bg-green-500 inline-block shadow-[0_0_0_3px_rgba(34,197,94,0.15)]"></span>Activo</span>'
-          : '<span class="inline-flex items-center gap-1.5 text-xs font-semibold text-slate-400"><span class="w-2 h-2 rounded-full bg-slate-300 inline-block"></span>Inactivo</span>';
+          ? '<span class="badge badge--success"><span class="material-symbols-outlined">check_circle</span>Activo</span>'
+          : '<span class="badge badge--neutral">Inactivo</span>';
       }
 
       function _initial(nombre) {

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -339,7 +339,7 @@
             </button>
           </div>
           <div class="overflow-x-auto">
-            <table class="w-full text-sm">
+            <table class="users-table w-full text-sm">
               <thead>
                 <tr class="bg-slate-50/60 text-left border-b border-slate-100">
                   <th

--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -741,7 +741,7 @@
               </div>
               <div id="validation-modal-body" class="max-h-[60vh] overflow-y-auto p-5"></div>
               <div class="flex flex-col gap-3 border-t border-slate-100 bg-slate-50/60 p-5 sm:flex-row sm:justify-end">
-                <button id="validation-modal-close" type="button" class="rounded-xl bg-gradient-to-r from-[#FF4B0B] to-[#FF681F] px-6 py-3 text-sm font-bold uppercase tracking-wide text-white shadow-md shadow-orange-200/60 transition-all hover:opacity-95 active:scale-[0.98]">Entendido</button>
+                <button id="validation-modal-close" type="button" class="btn-primary rounded-xl px-6 py-3 text-sm font-bold uppercase tracking-wide">Entendido</button>
               </div>
             </div>`;
           document.body.appendChild(modal);

--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -131,42 +131,36 @@
         <!-- Actions + stats -->
         <div class="flex-1 min-w-0">
           <div class="flex flex-col sm:flex-row sm:justify-end gap-3">
-            <button id="btn-nueva-captura" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-gradient-to-r from-[#FF4B0B] to-[#FF681F] hover:shadow-lg hover:shadow-orange-200 active:scale-[0.98] text-white font-bold rounded-xl shadow-md shadow-orange-200/60 transition-all">
+            <button id="btn-nueva-captura" class="btn-primary px-6 py-3">
               <span class="material-symbols-outlined text-xl">add_circle</span>
               <span>Nueva Captura</span>
             </button>
-            <button id="btn-editar-perfil" class="inline-flex items-center justify-center gap-2 px-6 py-3 bg-white hover:bg-orange-50 active:scale-[0.98] text-ug-orange-pure font-bold rounded-xl border-2 border-ug-orange-pure/70 transition-all">
+            <button id="btn-editar-perfil" class="btn-secondary px-6 py-3">
               <span class="material-symbols-outlined text-xl">edit</span>
               <span>Editar Perfil</span>
             </button>
           </div>
 
           <div class="mt-5 grid grid-cols-1 sm:grid-cols-3 gap-4">
-            <div class="rounded-2xl p-4 bg-purple-50/70 border border-purple-100 flex items-center gap-3">
-              <div class="w-11 h-11 rounded-full bg-white border border-purple-100 flex items-center justify-center shrink-0">
-                <span class="material-symbols-outlined text-primary text-xl">content_paste</span>
-              </div>
-              <div>
-                <p class="text-xs font-medium text-slate-500">Total de capturas</p>
-                <p class="text-2xl font-extrabold leading-tight" style="color: var(--c-title);" id="stat-capturas" data-countup>0</p>
+            <div class="stat-card">
+              <div class="stat-card__icon"><span class="material-symbols-outlined">content_paste</span></div>
+              <div class="stat-card__body">
+                <span class="stat-card__value" id="stat-capturas" data-countup>0</span>
+                <span class="stat-card__label">Total de capturas</span>
               </div>
             </div>
-            <div class="rounded-2xl p-4 bg-green-50/80 border border-green-100 flex items-center gap-3">
-              <div class="w-11 h-11 rounded-full bg-white border border-green-100 flex items-center justify-center shrink-0">
-                <span class="material-symbols-outlined text-green-600 text-xl">check_circle</span>
-              </div>
-              <div>
-                <p class="text-xs font-medium text-slate-500">Completados</p>
-                <p class="text-2xl font-extrabold leading-tight text-green-700" id="stat-completados" data-countup>0</p>
+            <div class="stat-card stat-card--success">
+              <div class="stat-card__icon"><span class="material-symbols-outlined">check_circle</span></div>
+              <div class="stat-card__body">
+                <span class="stat-card__value" id="stat-completados" data-countup>0</span>
+                <span class="stat-card__label">Completados</span>
               </div>
             </div>
-            <div class="rounded-2xl p-4 bg-orange-50/80 border border-orange-100 flex items-center gap-3">
-              <div class="w-11 h-11 rounded-full bg-white border border-orange-100 flex items-center justify-center shrink-0">
-                <span class="material-symbols-outlined text-ug-orange-pure text-xl">schedule</span>
-              </div>
-              <div>
-                <p class="text-xs font-medium text-slate-500">Pendientes</p>
-                <p class="text-2xl font-extrabold leading-tight text-ug-orange-pure" id="stat-pendientes" data-countup>0</p>
+            <div class="stat-card stat-card--warning">
+              <div class="stat-card__icon"><span class="material-symbols-outlined">schedule</span></div>
+              <div class="stat-card__body">
+                <span class="stat-card__value" id="stat-pendientes" data-countup>0</span>
+                <span class="stat-card__label">Pendientes</span>
               </div>
             </div>
           </div>
@@ -422,12 +416,12 @@
 
       const badgePills = `
         ${isLeaderOfAny ? `
-        <span class="inline-flex items-center gap-2 px-4 py-2.5 bg-orange-50 border border-orange-200 rounded-xl text-sm font-bold text-ug-orange-pure">
-          <span class="material-symbols-outlined text-lg">crown</span>
+        <span class="badge badge--lg badge--brand">
+          <span class="material-symbols-outlined">crown</span>
           Líder
         </span>` : ''}
-        <span class="inline-flex items-center gap-2 px-4 py-2.5 bg-green-50 border border-green-200 rounded-xl text-sm font-bold text-green-700">
-          <span class="material-symbols-outlined text-lg">verified_user</span>
+        <span class="badge badge--lg badge--success">
+          <span class="material-symbols-outlined">verified_user</span>
           Capturista activo
         </span>
       `;
@@ -615,11 +609,11 @@
       const legendHtml = `
         <div class="flex items-center gap-2 mt-4 text-xs text-slate-400 justify-end">
           <span>Menos</span>
-          <span class="heatmap-cell inline-block bg-[#ebedf0]"></span>
-          <span class="heatmap-cell inline-block bg-[#9be9a8]"></span>
-          <span class="heatmap-cell inline-block bg-[#40c463]"></span>
-          <span class="heatmap-cell inline-block bg-[#30a14e]"></span>
-          <span class="heatmap-cell inline-block bg-[#216e39]"></span>
+          <span class="heatmap-cell inline-block bg-[#F0E7E2]"></span>
+          <span class="heatmap-cell inline-block bg-[#FFD3BE]"></span>
+          <span class="heatmap-cell inline-block bg-[#FF9E70]"></span>
+          <span class="heatmap-cell inline-block bg-[#FF6A2C]"></span>
+          <span class="heatmap-cell inline-block bg-[#E8410A]"></span>
           <span>Más</span>
         </div>
       `;
@@ -653,11 +647,14 @@
   }
 
   function _heatColor(count) {
-    if (count === 0) return '#ebedf0';
-    if (count <= 2) return '#9be9a8';
-    if (count <= 5) return '#40c463';
-    if (count <= 9) return '#30a14e';
-    return '#216e39';
+    // Brand-aligned orange ramp (ties the heatmap to the UI palette) with
+    // stronger contrast between levels than the previous green scale.
+    const dark = document.documentElement.classList.contains('dark');
+    if (count === 0) return dark ? '#2A2340' : '#F0E7E2';
+    if (count <= 2) return '#FFD3BE';
+    if (count <= 5) return '#FF9E70';
+    if (count <= 9) return '#FF6A2C';
+    return dark ? '#FF5A1F' : '#E8410A';
   }
 
   function showHeatmapTooltip(ev, text) {

--- a/front/Capturista-view/seleccion-region.html
+++ b/front/Capturista-view/seleccion-region.html
@@ -145,7 +145,7 @@
         <!-- Submit -->
         <button
           id="btn-continuar" type="button"
-          class="btn-primary w-full py-4 text-sm rounded-xl group disabled:opacity-60 disabled:cursor-not-allowed"
+          class="btn-primary w-full py-3.5 text-sm rounded-xl group disabled:opacity-60 disabled:cursor-not-allowed"
         >
           <span id="btn-text">CONTINUAR</span>
           <span class="material-symbols-outlined text-xl group-hover:translate-x-1 transition-transform">arrow_forward</span>

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -3080,7 +3080,7 @@
               </div>
               <div id="validation-modal-body" class="max-h-[60vh] overflow-y-auto p-5"></div>
               <div class="flex flex-col gap-3 border-t border-slate-100 bg-slate-50/60 p-5 sm:flex-row sm:justify-end">
-                <button id="validation-modal-close" type="button" class="rounded-xl bg-gradient-to-r from-[#FF4B0B] to-[#FF681F] px-6 py-3 text-sm font-bold uppercase tracking-wide text-white shadow-md shadow-orange-200/60 transition-all hover:opacity-95 active:scale-[0.98]">Entendido</button>
+                <button id="validation-modal-close" type="button" class="btn-primary rounded-xl px-6 py-3 text-sm font-bold uppercase tracking-wide">Entendido</button>
               </div>
             </div>`;
           document.body.appendChild(modal);
@@ -3108,7 +3108,7 @@
                 <h3 class="text-sm font-black uppercase tracking-wide" style="color: var(--c-title);">${escapeHtml(form)}</h3>
                 <span class="rounded-full border border-red-200 bg-red-100 px-2 py-0.5 text-[11px] font-bold text-red-700">${items.length} ${items.length === 1 ? "error" : "errores"}</span>
               </div>
-              ${items[0].url ? `<button type="button" data-url="${escapeHtml(items[0].url)}" class="validation-jump rounded-lg border-2 border-ug-orange-pure/70 px-3 py-1.5 text-xs font-bold uppercase text-ug-orange-pure transition-all hover:bg-orange-50">Ir al formulario</button>` : ""}
+              ${items[0].url ? `<button type="button" data-url="${escapeHtml(items[0].url)}" class="validation-jump btn-secondary rounded-lg px-3 py-1.5 text-xs font-bold uppercase">Ir al formulario</button>` : ""}
             </div>
             <ul class="space-y-2 text-sm">${items.map((item) => `
               <li class="flex items-start gap-2.5 rounded-r-lg border-l-4 border-red-500 bg-red-50/70 px-3 py-2.5">

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -1895,7 +1895,7 @@
               </div>
               <div id="validation-modal-body" class="max-h-[60vh] overflow-y-auto p-5"></div>
               <div class="flex flex-col gap-3 border-t border-slate-100 bg-slate-50/60 p-5 sm:flex-row sm:justify-end">
-                <button id="validation-modal-close" type="button" class="rounded-xl bg-gradient-to-r from-[#FF4B0B] to-[#FF681F] px-6 py-3 text-sm font-bold uppercase tracking-wide text-white shadow-md shadow-orange-200/60 transition-all hover:opacity-95 active:scale-[0.98]">Entendido</button>
+                <button id="validation-modal-close" type="button" class="btn-primary rounded-xl px-6 py-3 text-sm font-bold uppercase tracking-wide">Entendido</button>
               </div>
             </div>`;
           document.body.appendChild(modal);

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -300,6 +300,31 @@
 
     <!-- ── Main Content ────────────────────────────────────────────────────── -->
     <main class="flex-1 max-w-7xl mx-auto w-full px-4 py-6">
+      <!-- Summary -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5">
+        <div class="stat-card">
+          <div class="stat-card__icon"><span class="material-symbols-outlined">assignment_ind</span></div>
+          <div class="stat-card__body">
+            <span class="stat-card__value" id="summary-asignados">0</span>
+            <span class="stat-card__label">Asignados</span>
+          </div>
+        </div>
+        <div class="stat-card stat-card--info">
+          <div class="stat-card__icon"><span class="material-symbols-outlined">visibility</span></div>
+          <div class="stat-card__body">
+            <span class="stat-card__value" id="summary-shown">0</span>
+            <span class="stat-card__label">En esta página</span>
+          </div>
+        </div>
+        <div class="stat-card stat-card--warning">
+          <div class="stat-card__icon"><span class="material-symbols-outlined">edit_note</span></div>
+          <div class="stat-card__body">
+            <span class="stat-card__value" id="summary-borradores">0</span>
+            <span class="stat-card__label">Borradores en página</span>
+          </div>
+        </div>
+      </div>
+
       <!-- Loading state -->
       <div
         id="state-loading"
@@ -971,6 +996,7 @@
           state.items = data.items || [];
           state.total = data.total || 0;
           state.page = data.page || 1;
+          updateSummary();
 
           if (state.items.length === 0) {
             showEmpty();
@@ -984,6 +1010,15 @@
         } finally {
           state.loading = false;
         }
+      }
+
+      // Top summary: assigned total, shown on this page, drafts on this page.
+      function updateSummary() {
+        const byId = function (id) { return document.getElementById(id); };
+        byId("summary-asignados").textContent = state.total;
+        byId("summary-shown").textContent = state.items.length;
+        byId("summary-borradores").textContent =
+          state.items.filter(function (i) { return i.solicitud_status === "borrador"; }).length;
       }
 
       // ═══════════════════════════════════════════════════════════════════════════

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -301,7 +301,7 @@
     <!-- ── Main Content ────────────────────────────────────────────────────── -->
     <main class="flex-1 max-w-7xl mx-auto w-full px-4 py-6">
       <!-- Summary -->
-      <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5">
+      <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5 rise">
         <div class="stat-card">
           <div class="stat-card__icon"><span class="material-symbols-outlined">assignment_ind</span></div>
           <div class="stat-card__body">

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -1314,12 +1314,13 @@
           { id: "obs",   label: "Observaciones", icon: "notes", html: panelObs },
           { id: "files", label: "Archivos", icon: "attach_file", html: panelFiles },
         ];
-        const nav = '<div class="modal-tabs" role="tablist">' + tabs.map(function (t, i) {
-          return '<button class="modal-tab' + (i === 0 ? " active" : "") + '" data-tab="' + t.id + '" role="tab">' +
-            '<span class="material-symbols-outlined">' + t.icon + '</span><span>' + t.label + '</span></button>';
+        const nav = '<div class="modal-tabs" role="tablist" aria-label="Secciones del beneficiario">' + tabs.map(function (t, i) {
+          return '<button class="modal-tab' + (i === 0 ? " active" : "") + '" data-tab="' + t.id + '" id="tab-' + t.id + '" role="tab"' +
+            ' aria-selected="' + (i === 0 ? "true" : "false") + '" aria-controls="panel-' + t.id + '">' +
+            '<span class="material-symbols-outlined" aria-hidden="true">' + t.icon + '</span><span>' + t.label + '</span></button>';
         }).join("") + "</div>";
         const panels = tabs.map(function (t, i) {
-          return '<div class="modal-panel' + (i === 0 ? "" : " hidden") + '" data-panel="' + t.id + '">' + (t.badge ? '<div class="mb-3">' + t.badge + '</div>' : "") + t.html + '</div>';
+          return '<div class="modal-panel' + (i === 0 ? "" : " hidden") + '" data-panel="' + t.id + '" id="panel-' + t.id + '" role="tabpanel" aria-labelledby="tab-' + t.id + '"' + (i === 0 ? "" : " hidden") + '>' + (t.badge ? '<div class="mb-3">' + t.badge + '</div>' : "") + t.html + '</div>';
         }).join("");
 
         modalContent.innerHTML = nav + '<div class="mt-4">' + panels + "</div>";
@@ -1328,8 +1329,16 @@
         modalContent.querySelectorAll(".modal-tab").forEach(function (btn) {
           btn.addEventListener("click", function () {
             const id = btn.dataset.tab;
-            modalContent.querySelectorAll(".modal-tab").forEach(function (b) { b.classList.toggle("active", b === btn); });
-            modalContent.querySelectorAll(".modal-panel").forEach(function (p) { p.classList.toggle("hidden", p.dataset.panel !== id); });
+            modalContent.querySelectorAll(".modal-tab").forEach(function (b) {
+              const on = b === btn;
+              b.classList.toggle("active", on);
+              b.setAttribute("aria-selected", on ? "true" : "false");
+            });
+            modalContent.querySelectorAll(".modal-panel").forEach(function (p) {
+              const show = p.dataset.panel === id;
+              p.classList.toggle("hidden", !show);
+              if (show) { p.removeAttribute("hidden"); } else { p.setAttribute("hidden", ""); }
+            });
             const body = document.getElementById("modal-body");
             if (body) body.scrollTop = 0;
             _updateModalScrollHint();

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -451,7 +451,7 @@
     >
       <div
         id="modal-container"
-        class="animate-fade-in bg-white w-full sm:max-w-lg sm:rounded-2xl sm:max-h-[90vh] flex flex-col shadow-2xl sm:mx-auto max-h-[92vh] rounded-t-2xl"
+        class="animate-fade-in bg-white w-full sm:max-w-lg sm:rounded-2xl sm:max-h-[90vh] flex flex-col shadow-2xl sm:mx-auto max-h-[92vh] rounded-t-2xl relative"
       >
         <!-- Modal header -->
         <div
@@ -490,6 +490,8 @@
           <!-- Content rendered by JS -->
           <div id="modal-content" class="hidden space-y-6"></div>
         </div>
+        <!-- Scroll-more indicator (shown when the body has more content below) -->
+        <div id="modal-scroll-hint" class="modal-scroll-hint hidden"></div>
         <!-- Modal footer (action buttons) -->
         <div
           id="modal-footer"
@@ -1197,158 +1199,143 @@
         modalTitle.textContent = ben.nombre || "—";
         modalFolio.textContent = "CURP: " + (ben.curp_benef || ben.folio || "—");
 
-        let html = "";
-
-        // ── Identificación ──
-        html += `
-      <section>
-        <h4 class="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
-          <span class="material-symbols-outlined text-sm">badge</span> Identificación
-        </h4>
-        <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
-          <div class="grid grid-cols-2 gap-2">
-            <div><span class="text-slate-400">Nombre:</span><br/><span class="font-medium">${_escapeHtml(ben.nombre || "—")}</span></div>
-            <div><span class="text-slate-400">CURP:</span><br/><span class="font-medium">${_escapeHtml(ben.curp_benef || ben.folio || "—")}</span></div>
-            <div><span class="text-slate-400">País:</span><br/><span class="font-medium">${_escapeHtml(ben.pais_nombre || "—")}</span></div>
-            <div><span class="text-slate-400">Región:</span><br/><span class="font-medium">${_escapeHtml(ben.region_nombre || "—")}</span></div>
-            <div><span class="text-slate-400">Ciudad:</span><br/><span class="font-medium">${_escapeHtml(ben.ciudad || "—")}</span></div>
-            <div><span class="text-slate-400">Sede:</span><br/><span class="font-medium">${_escapeHtml((data.estudio && data.estudio.sede) || ben.sede || "—")}</span></div>
-          </div>
-          <div><span class="text-slate-400">Diagnóstico:</span><br/><span class="font-medium">${_valOrNaHtml(ben.diagnostico)}</span></div>
-        </div>
-      </section>
-    `;
-
-        // ── Datos Clínicos ──
         const solicitudStatusBadge = solicitud.status === "borrador"
-          ? '<span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 border border-amber-300 ml-2">Borrador técnico</span>'
+          ? '<span class="badge badge--warning ml-2">Borrador técnico</span>'
           : (solicitud.status === "completo"
-              ? '<span class="text-[10px] font-bold px-2 py-0.5 rounded-full bg-green-100 text-green-700 border border-green-300 ml-2">Completo</span>'
+              ? '<span class="badge badge--success ml-2">Completo</span>'
               : "");
-        html += `
-      <section>
-        <h4 class="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
-          <span class="material-symbols-outlined text-sm">stethoscope</span> Datos Clínicos
-          ${solicitudStatusBadge}
-        </h4>
-        <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
-          <div class="grid grid-cols-2 gap-2">
-            ${(() => {
-              // Borradores store values verbatim in capture unit; finalized records are canonical in/lb.
-              const isBorrador = solicitud.status === "borrador";
-              const measureUnit = isBorrador ? (solicitud.unidad_captura || "in") : "in";
-              const weightUnit  = isBorrador ? (solicitud.unidad_peso_captura || "lb") : "lb";
-              return `
-            <div><span class="text-slate-400">Peso:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.peso_kg != null ? solicitud.peso_kg + " " + weightUnit : null)}</span></div>
-            <div><span class="text-slate-400">Altura total:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.altura_total_in != null ? solicitud.altura_total_in + " " + measureUnit : null)}</span></div>
-            <div><span class="text-slate-400">Cabeza-asiento:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_cabeza_asiento != null ? solicitud.medida_cabeza_asiento + " " + measureUnit : null)}</span></div>
-            <div><span class="text-slate-400">Hombro-asiento:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_hombro_asiento != null ? solicitud.medida_hombro_asiento + " " + measureUnit : null)}</span></div>
-            <div><span class="text-slate-400">Prof. asiento:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_prof_asiento != null ? solicitud.medida_prof_asiento + " " + measureUnit : null)}</span></div>
-            <div><span class="text-slate-400">Rodilla-talón:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_rodilla_talon != null ? solicitud.medida_rodilla_talon + " " + measureUnit : null)}</span></div>
-            <div><span class="text-slate-400">Ancho cadera:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_ancho_cadera != null ? solicitud.medida_ancho_cadera + " " + measureUnit : null)}</span></div>
-              `;
-            })()}
-          </div>
-          <div class="mt-2 pt-2 border-t border-slate-200">
-            <div><span class="text-slate-400">Control tronco:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.control_tronco)}</span></div>
-            <div><span class="text-slate-400">Control cabeza:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.control_cabeza)}</span></div>
-            <div><span class="text-slate-400">Observaciones:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.padecimiento)}</span></div>
-          </div>
-        </div>
-      </section>
-    `;
 
-        // ── Fotografía ──
-        html += `
-      <section>
-        <h4 class="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
-          <span class="material-symbols-outlined text-sm">photo_camera</span> Fotografía
-        </h4>
-        <div class="bg-slate-50 rounded-xl p-4 flex items-center justify-center min-h-[120px]">
+        // ── Panel: Identificación (datos + contacto/tutores) ──
+        const panelIdent = `
+      <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
+        <div class="grid grid-cols-2 gap-2">
+          <div><span class="text-slate-400">Nombre:</span><br/><span class="font-medium">${_escapeHtml(ben.nombre || "—")}</span></div>
+          <div><span class="text-slate-400">CURP:</span><br/><span class="font-medium">${_escapeHtml(ben.curp_benef || ben.folio || "—")}</span></div>
+          <div><span class="text-slate-400">País:</span><br/><span class="font-medium">${_escapeHtml(ben.pais_nombre || "—")}</span></div>
+          <div><span class="text-slate-400">Región:</span><br/><span class="font-medium">${_escapeHtml(ben.region_nombre || "—")}</span></div>
+          <div><span class="text-slate-400">Ciudad:</span><br/><span class="font-medium">${_escapeHtml(ben.ciudad || "—")}</span></div>
+          <div><span class="text-slate-400">Sede:</span><br/><span class="font-medium">${_escapeHtml((data.estudio && data.estudio.sede) || ben.sede || "—")}</span></div>
+        </div>
+        <div><span class="text-slate-400">Diagnóstico:</span><br/><span class="font-medium">${_valOrNaHtml(ben.diagnostico)}</span></div>
+      </div>
+      <p class="t-caption mt-4 mb-2">Contacto</p>
+      <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
+        <div><span class="text-slate-400">Teléfonos:</span><br/><span class="font-medium">${_valOrNaHtml(ben.telefonos)}</span></div>
+        <div class="mt-2 pt-2 border-t border-slate-200">
+          <span class="text-slate-400 text-xs font-semibold">Tutores / Referencias</span>
           ${
-            solicitud.foto_url_resolved
-              ? '<img src="' +
-                _escapeHtml(solicitud.foto_url_resolved) +
-                '" alt="Foto del paciente" class="max-h-64 w-auto max-w-full rounded-lg object-contain shadow-sm" onerror="this.onerror=null;this.parentElement.innerHTML=\'<span class=\\\'text-slate-400 text-sm\\\'>Imagen no disponible</span>\'" />'
-              : '<div class="text-center"><span class="material-symbols-outlined text-slate-300 text-4xl block mb-2">image</span><span class="text-slate-400 text-sm">Sin foto</span></div>'
+            tutores.length === 0
+              ? '<p class="text-slate-300 italic text-sm mt-1">Sin tutores registrados</p>'
+              : tutores
+                  .map(function (t) {
+                    return (
+                      '<div class="mt-2 text-sm"><span class="font-medium">Tutor ' +
+                      t.numero_tutor +
+                      ":</span> " +
+                      _escapeHtml(t.nombre || "—") +
+                      (t.edad ? " (" + t.edad + " años)" : "") +
+                      (t.telefono ? " · " + _escapeHtml(t.telefono) : "") +
+                      "</div>"
+                    );
+                  })
+                  .join("")
           }
         </div>
-      </section>
+      </div>
     `;
 
-        // ── Documentos (credencial + comprobante) ──
-        const hasCredencial = estudio && estudio.credencial_url_resolved;
-        const hasComprobante =
-          estudio && estudio.comprobante_domicilio_url_resolved;
-        if (hasCredencial || hasComprobante) {
-          html += `
-        <section>
-          <h4 class="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
-            <span class="material-symbols-outlined text-sm">description</span> Documentos
-          </h4>
-          <div class="bg-slate-50 rounded-xl p-4 space-y-3 text-sm">
-            ${
-              hasCredencial
-                ? `
-              <div>
-                <span class="text-slate-400 text-xs font-semibold block mb-1">Credencial</span>
-                <a href="${_escapeHtml(estudio.credencial_url_resolved)}" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-primary hover:underline">
-                  <span class="material-symbols-outlined text-sm">open_in_new</span> Ver credencial
-                </a>
-              </div>
-            `
-                : ""
-            }
-            ${
-              hasComprobante
-                ? `
-              <div>
-                <span class="text-slate-400 text-xs font-semibold block mb-1">Comprobante de domicilio</span>
-                <a href="${_escapeHtml(estudio.comprobante_domicilio_url_resolved)}" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-primary hover:underline">
-                  <span class="material-symbols-outlined text-sm">open_in_new</span> Ver comprobante
-                </a>
-              </div>
-            `
-                : ""
-            }
-          </div>
-        </section>
-      `;
-        }
-
-        // ── Contacto / Tutores ──
-        html += `
-      <section>
-        <h4 class="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
-          <span class="material-symbols-outlined text-sm">contacts</span> Contacto
-        </h4>
-        <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
-          <div><span class="text-slate-400">Teléfonos:</span><br/><span class="font-medium">${_valOrNaHtml(ben.telefonos)}</span></div>
-          <div class="mt-2 pt-2 border-t border-slate-200">
-            <span class="text-slate-400 text-xs font-semibold">Tutores / Referencias</span>
-            ${
-              tutores.length === 0
-                ? '<p class="text-slate-300 italic text-sm mt-1">Sin tutores registrados</p>'
-                : tutores
-                    .map(function (t) {
-                      return (
-                        '<div class="mt-2 text-sm"><span class="font-medium">Tutor ' +
-                        t.numero_tutor +
-                        ":</span> " +
-                        _escapeHtml(t.nombre || "—") +
-                        (t.edad ? " (" + t.edad + " años)" : "") +
-                        (t.telefono ? " · " + _escapeHtml(t.telefono) : "") +
-                        "</div>"
-                      );
-                    })
-                    .join("")
-            }
-          </div>
+        // ── Panel: Datos clínicos (medidas) ──
+        const panelClin = `
+      <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
+        <div class="grid grid-cols-2 gap-2">
+          ${(() => {
+            // Borradores store values verbatim in capture unit; finalized records are canonical in/lb.
+            const isBorrador = solicitud.status === "borrador";
+            const measureUnit = isBorrador ? (solicitud.unidad_captura || "in") : "in";
+            const weightUnit  = isBorrador ? (solicitud.unidad_peso_captura || "lb") : "lb";
+            return `
+          <div><span class="text-slate-400">Peso:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.peso_kg != null ? solicitud.peso_kg + " " + weightUnit : null)}</span></div>
+          <div><span class="text-slate-400">Altura total:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.altura_total_in != null ? solicitud.altura_total_in + " " + measureUnit : null)}</span></div>
+          <div><span class="text-slate-400">Cabeza-asiento:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_cabeza_asiento != null ? solicitud.medida_cabeza_asiento + " " + measureUnit : null)}</span></div>
+          <div><span class="text-slate-400">Hombro-asiento:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_hombro_asiento != null ? solicitud.medida_hombro_asiento + " " + measureUnit : null)}</span></div>
+          <div><span class="text-slate-400">Prof. asiento:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_prof_asiento != null ? solicitud.medida_prof_asiento + " " + measureUnit : null)}</span></div>
+          <div><span class="text-slate-400">Rodilla-talón:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_rodilla_talon != null ? solicitud.medida_rodilla_talon + " " + measureUnit : null)}</span></div>
+          <div><span class="text-slate-400">Ancho cadera:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.medida_ancho_cadera != null ? solicitud.medida_ancho_cadera + " " + measureUnit : null)}</span></div>
+            `;
+          })()}
         </div>
-      </section>
+      </div>
     `;
 
-        modalContent.innerHTML = html;
+        // ── Panel: Observaciones (control postural + notas) ──
+        const panelObs = `
+      <div class="bg-slate-50 rounded-xl p-4 space-y-2 text-sm">
+        <div><span class="text-slate-400">Control tronco:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.control_tronco)}</span></div>
+        <div><span class="text-slate-400">Control cabeza:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.control_cabeza)}</span></div>
+        <div class="mt-2 pt-2 border-t border-slate-200"><span class="text-slate-400">Observaciones:</span><br/><span class="font-medium">${_valOrNaHtml(solicitud.padecimiento)}</span></div>
+      </div>
+    `;
+
+        // ── Panel: Archivos (foto + documentos) ──
+        const hasCredencial = estudio && estudio.credencial_url_resolved;
+        const hasComprobante = estudio && estudio.comprobante_domicilio_url_resolved;
+        const fotoHtml = solicitud.foto_url_resolved
+          ? '<img src="' + _escapeHtml(solicitud.foto_url_resolved) + '" alt="Foto del paciente" class="max-h-64 w-auto max-w-full rounded-lg object-contain shadow-sm" onerror="this.onerror=null;this.parentElement.innerHTML=\'<span class=\\\'text-slate-400 text-sm\\\'>Imagen no disponible</span>\'" />'
+          : '<div class="text-center"><span class="material-symbols-outlined text-slate-300 text-4xl block mb-2">image</span><span class="text-slate-400 text-sm">Sin foto</span></div>';
+        const docsHtml = (hasCredencial || hasComprobante)
+          ? `
+        <p class="t-caption mt-4 mb-2">Documentos</p>
+        <div class="bg-slate-50 rounded-xl p-4 space-y-3 text-sm">
+          ${hasCredencial ? `
+          <div>
+            <span class="text-slate-400 text-xs font-semibold block mb-1">Credencial</span>
+            <a href="${_escapeHtml(estudio.credencial_url_resolved)}" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-primary hover:underline">
+              <span class="material-symbols-outlined text-sm">open_in_new</span> Ver credencial
+            </a>
+          </div>` : ""}
+          ${hasComprobante ? `
+          <div>
+            <span class="text-slate-400 text-xs font-semibold block mb-1">Comprobante de domicilio</span>
+            <a href="${_escapeHtml(estudio.comprobante_domicilio_url_resolved)}" target="_blank" rel="noopener" class="inline-flex items-center gap-2 text-primary hover:underline">
+              <span class="material-symbols-outlined text-sm">open_in_new</span> Ver comprobante
+            </a>
+          </div>` : ""}
+        </div>` : "";
+        const panelFiles = `
+      <p class="t-caption mb-2">Fotografía</p>
+      <div class="bg-slate-50 rounded-xl p-4 flex items-center justify-center min-h-[120px]">${fotoHtml}</div>
+      ${docsHtml}
+    `;
+
+        // ── Assemble tabs ──
+        const tabs = [
+          { id: "ident", label: "Identificación", icon: "badge", html: panelIdent },
+          { id: "clin",  label: "Datos clínicos", icon: "stethoscope", html: panelClin, badge: solicitudStatusBadge },
+          { id: "obs",   label: "Observaciones", icon: "notes", html: panelObs },
+          { id: "files", label: "Archivos", icon: "attach_file", html: panelFiles },
+        ];
+        const nav = '<div class="modal-tabs" role="tablist">' + tabs.map(function (t, i) {
+          return '<button class="modal-tab' + (i === 0 ? " active" : "") + '" data-tab="' + t.id + '" role="tab">' +
+            '<span class="material-symbols-outlined">' + t.icon + '</span><span>' + t.label + '</span></button>';
+        }).join("") + "</div>";
+        const panels = tabs.map(function (t, i) {
+          return '<div class="modal-panel' + (i === 0 ? "" : " hidden") + '" data-panel="' + t.id + '">' + (t.badge ? '<div class="mb-3">' + t.badge + '</div>' : "") + t.html + '</div>';
+        }).join("");
+
+        modalContent.innerHTML = nav + '<div class="mt-4">' + panels + "</div>";
+
+        // Tab switching
+        modalContent.querySelectorAll(".modal-tab").forEach(function (btn) {
+          btn.addEventListener("click", function () {
+            const id = btn.dataset.tab;
+            modalContent.querySelectorAll(".modal-tab").forEach(function (b) { b.classList.toggle("active", b === btn); });
+            modalContent.querySelectorAll(".modal-panel").forEach(function (p) { p.classList.toggle("hidden", p.dataset.panel !== id); });
+            const body = document.getElementById("modal-body");
+            if (body) body.scrollTop = 0;
+            _updateModalScrollHint();
+          });
+        });
+        _updateModalScrollHint();
         // Vista de solo lectura: el técnico ya no opera el proceso de manufactura.
         modalFooter.classList.add("hidden");
         modalFooter.innerHTML = "";
@@ -1445,6 +1432,17 @@
         document.body.classList.remove("overflow-hidden");
         currentDetail = null;
       }
+
+      // Scroll-more indicator: show a bottom fade + chevron while the modal body
+      // has content below the fold; hide it once scrolled to the end.
+      function _updateModalScrollHint() {
+        const body = document.getElementById("modal-body");
+        const hint = document.getElementById("modal-scroll-hint");
+        if (!body || !hint) return;
+        const moreBelow = body.scrollHeight - body.scrollTop - body.clientHeight > 8;
+        hint.classList.toggle("hidden", !moreBelow);
+      }
+      $("modal-body").addEventListener("scroll", _updateModalScrollHint);
 
       btnCloseModal.addEventListener("click", closeModal);
       modalOverlay.addEventListener("click", function (e) {

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -320,7 +320,7 @@
           <div class="stat-card__icon"><span class="material-symbols-outlined">edit_note</span></div>
           <div class="stat-card__body">
             <span class="stat-card__value" id="summary-borradores">0</span>
-            <span class="stat-card__label">Borradores en página</span>
+            <span class="stat-card__label">En proceso (página)</span>
           </div>
         </div>
       </div>

--- a/front/_styleguide.html
+++ b/front/_styleguide.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Style Guide — Fase 0 · Ecosistema VIDA UG</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;500;600;700;800&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet"/>
+    <link href="assets/css/theme.css" rel="stylesheet"/>
+    <style>
+      body { padding: 2rem 1.5rem 4rem; }
+      .wrap { max-width: 980px; margin: 0 auto; display: flex; flex-direction: column; gap: 1.5rem; }
+      .panel { padding: 1.5rem 1.75rem; }
+      .row { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+      .grid-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 1rem; }
+      .swatch { display: flex; flex-direction: column; gap: 4px; }
+      .swatch__chip { height: 44px; border-radius: 10px; border: 1px solid rgba(0,0,0,0.06); }
+    </style>
+  </head>
+  <body class="page-bg">
+    <div class="wrap">
+      <header class="row" style="justify-content: space-between;">
+        <div>
+          <p class="t-caption">Sistema de diseño · Fase 0</p>
+          <h1 class="t-page-title">Fundaciones visuales</h1>
+          <p class="t-subtitle">Escala tipográfica, color, botones, badges, stat-cards y microinteracciones.</p>
+        </div>
+        <button class="btn-tertiary" onclick="document.documentElement.classList.toggle('dark')">
+          <span class="material-symbols-outlined">dark_mode</span> Alternar tema
+        </button>
+      </header>
+
+      <!-- Type scale -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Escala tipográfica</h2>
+        <p class="t-page-title">Page title — t-page-title</p>
+        <p class="t-section-title">Section title — t-section-title</p>
+        <p class="t-card-title">Card title — t-card-title</p>
+        <p class="t-body">Body — t-body. Texto de lectura con contraste alto y line-height cómodo para párrafos largos.</p>
+        <p class="t-subtitle">Subtitle — t-subtitle, para descripciones secundarias.</p>
+        <p class="t-label">Label — t-label</p>
+        <p class="t-caption">Caption / eyebrow — t-caption</p>
+      </section>
+
+      <!-- Buttons -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Jerarquía de botones</h2>
+        <div class="row">
+          <button class="btn-primary" style="padding: 0.6rem 1.25rem;">Primario</button>
+          <button class="btn-secondary" style="padding: 0.6rem 1.25rem;">Secundario</button>
+          <button class="btn-tertiary" style="padding: 0.6rem 1.25rem;">Terciario / ghost</button>
+          <button class="btn-primary" style="padding: 0.6rem 1.25rem;" disabled>Deshabilitado</button>
+        </div>
+      </section>
+
+      <!-- Color scale -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Escala de color semántica</h2>
+        <div class="grid-stats">
+          <div class="swatch"><div class="swatch__chip" style="background: var(--c-success-bg);"></div><span class="t-label" style="color: var(--c-success);">success</span></div>
+          <div class="swatch"><div class="swatch__chip" style="background: var(--c-warning-bg);"></div><span class="t-label" style="color: var(--c-warning);">warning</span></div>
+          <div class="swatch"><div class="swatch__chip" style="background: var(--c-danger-bg);"></div><span class="t-label" style="color: var(--c-danger);">danger</span></div>
+          <div class="swatch"><div class="swatch__chip" style="background: var(--c-info-bg);"></div><span class="t-label" style="color: var(--c-info);">info</span></div>
+          <div class="swatch"><div class="swatch__chip" style="background: var(--c-neutral-bg);"></div><span class="t-label" style="color: var(--c-neutral);">neutral</span></div>
+          <div class="swatch"><div class="swatch__chip" style="background: var(--c-role-bg);"></div><span class="t-label" style="color: var(--c-role);">role</span></div>
+        </div>
+      </section>
+
+      <!-- Badges -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Badge — variantes por categoría</h2>
+        <div class="row">
+          <span class="badge badge--success"><span class="material-symbols-outlined">check_circle</span>Completado</span>
+          <span class="badge badge--warning">Borrador</span>
+          <span class="badge badge--danger">Vencido</span>
+          <span class="badge badge--info">En revisión</span>
+          <span class="badge badge--neutral">Sin iniciar</span>
+          <span class="badge badge--role">Capturista</span>
+          <span class="badge badge--brand">Admin</span>
+          <span class="badge badge--outline">Rotary León</span>
+        </div>
+      </section>
+
+      <!-- Stat cards -->
+      <section>
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Stat cards</h2>
+        <div class="grid-stats">
+          <div class="stat-card">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">groups</span></div>
+            <div class="stat-card__body"><span class="stat-card__value">128</span><span class="stat-card__label">Total</span></div>
+          </div>
+          <div class="stat-card stat-card--success">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">task_alt</span></div>
+            <div class="stat-card__body"><span class="stat-card__value">96</span><span class="stat-card__label">Completados</span></div>
+          </div>
+          <div class="stat-card stat-card--warning">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">edit_note</span></div>
+            <div class="stat-card__body"><span class="stat-card__value">32</span><span class="stat-card__label">Borradores</span></div>
+          </div>
+          <div class="stat-card stat-card--info">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">schedule</span></div>
+            <div class="stat-card__body"><span class="stat-card__value">7</span><span class="stat-card__label">Pendientes</span></div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Skeleton + check -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Microinteracciones</h2>
+        <div style="display: flex; flex-direction: column; gap: 0.6rem; max-width: 320px;">
+          <div class="skeleton" style="height: 16px; width: 70%;"></div>
+          <div class="skeleton" style="height: 16px; width: 90%;"></div>
+          <div class="skeleton" style="height: 16px; width: 50%;"></div>
+        </div>
+        <p class="t-body" style="margin-top: 1rem;">
+          Check de éxito:
+          <span class="sr-check material-symbols-outlined" style="color: var(--c-success); vertical-align: middle;">check_circle</span>
+        </p>
+      </section>
+    </div>
+  </body>
+</html>

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -158,9 +158,10 @@
               <input id="input-search" type="search" autocomplete="off" placeholder="Buscar por nombre, CURP, ciudad, región, país…"
                 class="w-full pl-10 pr-4 py-2.5 text-sm"/>
             </div>
-            <button id="btn-toggle-filters" title="Filtros"
+            <button id="btn-toggle-filters" title="Filtros" aria-label="Mostrar u ocultar filtros"
+              aria-expanded="false" aria-controls="filter-panel"
               class="btn-icon relative shrink-0" style="width: 44px; height: 44px;">
-              <span class="material-symbols-outlined">tune</span>
+              <span class="material-symbols-outlined" aria-hidden="true">tune</span>
               <span id="filter-dot" class="hidden absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-ug-orange-pure border-2 border-white"></span>
             </button>
           </div>
@@ -604,8 +605,9 @@
       // FILTER PANEL
       // ═══════════════════════════════════════════════════════════════════════════
       $("btn-toggle-filters").addEventListener("click", function () {
-        filterPanel.classList.toggle("open");
+        const open = filterPanel.classList.toggle("open");
         this.classList.toggle("border-primary"); this.classList.toggle("text-primary");
+        this.setAttribute("aria-expanded", open ? "true" : "false");
       });
 
       filterPais.addEventListener("change", async function () {

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -159,8 +159,9 @@
                 class="w-full pl-10 pr-4 py-2.5 text-sm"/>
             </div>
             <button id="btn-toggle-filters" title="Filtros"
-              class="w-10 h-10 rounded-xl bg-slate-100 hover:bg-slate-200 border-2 border-slate-200 flex items-center justify-center text-slate-500 hover:text-primary transition-all shrink-0">
-              <span class="material-symbols-outlined text-xl">tune</span>
+              class="btn-icon relative shrink-0" style="width: 44px; height: 44px;">
+              <span class="material-symbols-outlined">tune</span>
+              <span id="filter-dot" class="hidden absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-ug-orange-pure border-2 border-white"></span>
             </button>
           </div>
 
@@ -230,6 +231,31 @@
       </div>
 
       <main class="flex-1 max-w-7xl mx-auto w-full px-4 py-6">
+        <!-- Summary -->
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5">
+          <div class="stat-card">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">groups</span></div>
+            <div class="stat-card__body">
+              <span class="stat-card__value" id="summary-total">0</span>
+              <span class="stat-card__label">Total de beneficiarios</span>
+            </div>
+          </div>
+          <div class="stat-card stat-card--info">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">visibility</span></div>
+            <div class="stat-card__body">
+              <span class="stat-card__value" id="summary-shown">0</span>
+              <span class="stat-card__label">En esta página</span>
+            </div>
+          </div>
+          <div class="stat-card stat-card--warning">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">filter_alt</span></div>
+            <div class="stat-card__body">
+              <span class="stat-card__value" id="summary-filters">0</span>
+              <span class="stat-card__label">Filtros activos</span>
+            </div>
+          </div>
+        </div>
+
         <!-- Loading -->
         <div id="state-loading" class="hidden py-20" data-thinking="Acomodando expedientes"></div>
 
@@ -636,7 +662,7 @@
       $("btn-apply-filters").addEventListener("click", function () { state.page = 1; loadBeneficiarios(); });
       $("btn-clear-selection").addEventListener("click", function () { state.selectedIds.clear(); renderList(); _updateSelectionUI(); });
 
-      function updateFilterCount() {
+      function _activeFilterCount() {
         let count = 0;
         if (inputSearch.value.trim()) count++;
         if (filterPais.value) count++;
@@ -646,7 +672,21 @@
         if (filterPesoMin.value || filterPesoMax.value) count++;
         if (filterAlturaMin.value || filterAlturaMax.value) count++;
         if (filterFoto.value) count++;
+        return count;
+      }
+
+      function updateFilterCount() {
+        const count = _activeFilterCount();
         filterCount.textContent = count > 0 ? count + " filtro(s) activo(s)" : "";
+        const dot = document.getElementById("filter-dot");
+        if (dot) dot.classList.toggle("hidden", count === 0);
+      }
+
+      // Top summary: total matching, shown on this page, active filters.
+      function updateSummary() {
+        $("summary-total").textContent = state.total;
+        $("summary-shown").textContent = state.items.length;
+        $("summary-filters").textContent = _activeFilterCount();
       }
 
       function readFilters() {
@@ -683,6 +723,7 @@
           if (!res.ok) throw new Error("HTTP " + res.status);
           const data = await res.json();
           state.items = data.items || []; state.total = data.total || 0;
+          updateSummary();
           if (state.items.length === 0) { _showState("empty"); }
           else { _showState("content"); renderList(); }
           _updatePagination();

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -232,7 +232,7 @@
 
       <main class="flex-1 max-w-7xl mx-auto w-full px-4 py-6">
         <!-- Summary -->
-        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5">
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5 rise">
           <div class="stat-card">
             <div class="stat-card__icon"><span class="material-symbols-outlined">groups</span></div>
             <div class="stat-card__body">

--- a/front/assets/css/admin-usuarios.css
+++ b/front/assets/css/admin-usuarios.css
@@ -4,3 +4,22 @@
 input, select, textarea {
   caret-color: var(--c-orange);
 }
+
+/* ── Responsive users table: stack rows as cards below md (no horizontal scroll) ──
+   Columns: 1 Usuario · 2 Correo (hidden <md) · 3 Rol · 4 Estado · 5 Acción */
+@media (max-width: 767px) {
+  .users-table thead { display: none; }
+  .users-table tbody tr {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 16px;
+  }
+  .users-table tbody td { padding: 0 !important; }
+  .users-table tbody td:nth-child(1) { flex: 1 1 100%; }   /* user (avatar + name + email) */
+  .users-table tbody td:nth-child(3),                       /* rol badge */
+  .users-table tbody td:nth-child(4) { flex: 0 0 auto; }    /* estado badge */
+  .users-table tbody td:nth-child(5) { flex: 1 1 auto; }    /* actions */
+  .users-table tbody td:nth-child(5) > div { justify-content: flex-end; }
+}

--- a/front/assets/css/login.css
+++ b/front/assets/css/login.css
@@ -245,6 +245,17 @@ input, select, textarea {
 .video-player video {
   display: block;
   border-radius: var(--radius-card);
+  /* Calm the footage slightly so it supports rather than competes with login */
+  filter: saturate(0.96) brightness(0.97);
+}
+/* Soft brand-tinted overlay: lets the video recede behind the access form */
+.video-player::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-card);
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(43, 6, 61, 0.10) 0%, rgba(43, 6, 61, 0.30) 100%);
 }
 
 /* ── Header spacing: reference has 35–45px top air ── */
@@ -254,28 +265,17 @@ input, select, textarea {
 }
 
 /* ── Logo sizes ── */
+/* Normalized to one optical height so no single logo dominates the row;
+   width is intrinsic so each keeps its aspect ratio, and the header centers
+   them vertically (optical-center alignment). */
 .logo-vida-ug,
 .logo-hope-haven,
 .logo-rotary {
   /* Blend white logo canvases into the warm background */
   mix-blend-mode: multiply;
-}
-.logo-vida-ug {
-  width: 132px;
-  height: auto;
-  max-height: 80px;
-  object-fit: contain;
-}
-.logo-hope-haven {
-  width: 360px;
-  height: auto;
-  max-height: 90px;
-  object-fit: contain;
-}
-.logo-rotary {
-  width: 150px;
-  height: auto;
-  max-height: 70px;
+  height: 58px;
+  width: auto;
+  max-width: 100%;
   object-fit: contain;
 }
 

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -872,3 +872,165 @@ html.dark .badge-finalizado  { background: rgba(34, 197, 94, 0.20); color: #86EF
 @media (prefers-reduced-motion: reduce) {
   .sr-spark { animation: none; }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   FASE 0 — UNIFIED FOUNDATIONS
+   Type scale, semantic color scale, button hierarchy, Badge, stat-card and
+   micro-interaction primitives. Additive: pages opt in by using these classes.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* ── Type scale (single ramp, all modules) ── */
+  --text-page:   clamp(1.5rem, 1.15rem + 1.4vw, 1.875rem); /* page title  24→30 */
+  --text-h2:     1.25rem;    /* section title            20 */
+  --text-h3:     1.0625rem;  /* card title               17 */
+  --text-body:   0.9375rem;  /* body (matches inputs)    15 */
+  --text-sm:     0.8125rem;  /* secondary / table        13 */
+  --text-xs:     0.6875rem;  /* caption / eyebrow        11 */
+
+  /* ── Semantic status scale (AA ink on its own bg) ── */
+  --c-success:    #15803D;  --c-success-bg: #DCFCE7;
+  --c-warning:    #B45309;  --c-warning-bg: #FEF3C7;
+  --c-danger:     #B91C1C;  --c-danger-bg:  #FEE2E2;
+  --c-info:       #1D4ED8;  --c-info-bg:    #DBEAFE;
+  --c-neutral:    #475569;  --c-neutral-bg: #F1F5F9;
+  --c-role:       #7E22CE;  --c-role-bg:    rgba(147, 51, 234, 0.12);
+
+  /* ── Spacing rhythm ── */
+  --space-card:   1.25rem;   /* canonical inner card padding */
+}
+
+/* ── Type scale utilities ── */
+.t-page-title    { font-size: var(--text-page); font-weight: 800; line-height: 1.15; letter-spacing: -0.02em; color: var(--c-title); }
+.t-section-title { font-size: var(--text-h2);   font-weight: 700; line-height: 1.25; color: var(--c-title); }
+.t-card-title    { font-size: var(--text-h3);   font-weight: 700; line-height: 1.3;  color: var(--c-title); }
+.t-subtitle      { font-size: var(--text-body); font-weight: 400; line-height: 1.5;  color: var(--c-subtitle); }
+.t-body          { font-size: var(--text-body); line-height: 1.6; color: #334155; }
+.t-label         { font-size: var(--text-sm);   font-weight: 600; letter-spacing: 0.01em; color: var(--c-label); }
+.t-caption       { font-size: var(--text-xs);   font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--c-gray); }
+
+/* ── Tertiary / ghost button (third level under primary + secondary) ── */
+.btn-tertiary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: transparent;
+  color: var(--c-label);
+  font-weight: 600;
+  border: none;
+  border-radius: var(--radius-btn);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, transform 0.15s;
+}
+.btn-tertiary:hover  { background: rgba(43, 6, 61, 0.06); color: var(--c-title); }
+.btn-tertiary:active { transform: scale(0.98); }
+.btn-tertiary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Badge — one component, variants by category (estado / rol / organización) ── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.badge .material-symbols-outlined { font-size: 13px; }
+.badge--neutral { background: var(--c-neutral-bg); color: var(--c-neutral); }
+.badge--success { background: var(--c-success-bg); color: var(--c-success); }
+.badge--warning { background: var(--c-warning-bg); color: var(--c-warning); }
+.badge--danger  { background: var(--c-danger-bg);  color: var(--c-danger); }
+.badge--info    { background: var(--c-info-bg);    color: var(--c-info); }
+.badge--brand   { background: var(--c-orange-light); color: var(--c-orange-hover); }
+.badge--role    { background: var(--c-role-bg);    color: var(--c-role); }       /* rol */
+.badge--outline { background: transparent; border: 1px solid var(--c-separator); color: var(--c-label); } /* organización */
+
+/* ── Stat card — uniform metric tile (perfil, organización, admin) ── */
+.stat-card {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-card);
+  transition: box-shadow 0.2s ease-out, transform 0.2s ease-out;
+}
+.stat-card:hover { box-shadow: var(--shadow-card-lg); transform: translateY(-2px); }
+.stat-card__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--c-orange-light);
+  color: var(--c-orange);
+}
+.stat-card__icon .material-symbols-outlined { font-size: 22px; }
+.stat-card__body  { display: flex; flex-direction: column; line-height: 1.1; }
+.stat-card__value { font-size: 1.5rem; font-weight: 800; color: var(--c-title); letter-spacing: -0.01em; }
+.stat-card__label { font-size: var(--text-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--c-gray); margin-top: 2px; }
+.stat-card--success .stat-card__icon { background: var(--c-success-bg); color: var(--c-success); }
+.stat-card--warning .stat-card__icon { background: var(--c-warning-bg); color: var(--c-warning); }
+.stat-card--info    .stat-card__icon { background: var(--c-info-bg);    color: var(--c-info); }
+.stat-card--danger  .stat-card__icon { background: var(--c-danger-bg);  color: var(--c-danger); }
+
+/* ── Interactive surface (clickable cards / rows) ── */
+.interactive { cursor: pointer; transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.15s ease; }
+.interactive:hover { transform: translateY(-2px); }
+
+/* ── Skeleton loader ── */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: #ECE6E3;
+  border-radius: 8px;
+}
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+  animation: sr-shimmer 1.3s infinite;
+}
+@keyframes sr-shimmer { 100% { transform: translateX(100%); } }
+
+/* ── Success check pop ── */
+@keyframes sr-check-pop {
+  0%   { transform: scale(0); }
+  60%  { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}
+.sr-check { display: inline-block; animation: sr-check-pop 0.4s cubic-bezier(0.22, 1.4, 0.36, 1) both; }
+
+/* ── Dark-mode treatment for Fase 0 components ── */
+html.dark {
+  --c-success-bg: rgba(34, 197, 94, 0.18);  --c-success: #86EFAC;
+  --c-warning-bg: rgba(245, 158, 11, 0.18); --c-warning: #FCD34D;
+  --c-danger-bg:  rgba(239, 68, 68, 0.18);  --c-danger:  #FCA5A5;
+  --c-info-bg:    rgba(59, 130, 246, 0.18); --c-info:    #BFDBFE;
+  --c-neutral-bg: #2E2744;                  --c-neutral: #B4AAC2;
+  --c-role-bg:    rgba(147, 51, 234, 0.20); --c-role:    #D8B4FE;
+}
+html.dark .t-body { color: #C9C2D6; }
+html.dark .btn-tertiary:hover { background: rgba(255, 255, 255, 0.07); color: var(--c-title); }
+html.dark .badge--outline { border-color: rgba(255, 255, 255, 0.16); color: var(--c-label); }
+html.dark .stat-card { background: rgba(27, 21, 41, 0.94); border-color: rgba(255, 255, 255, 0.07); }
+html.dark .stat-card__icon { background: rgba(255, 90, 31, 0.14); color: #FFB088; }
+html.dark .skeleton { background: #2A2340; }
+html.dark .skeleton::after { background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.08), transparent); }
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-card:hover, .interactive:hover { transform: none; }
+  .skeleton::after { animation: none; }
+  .sr-check { animation: none; }
+}

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -941,6 +941,8 @@ html.dark .badge-finalizado  { background: rgba(34, 197, 94, 0.20); color: #86EF
   white-space: nowrap;
 }
 .badge .material-symbols-outlined { font-size: 13px; }
+.badge--lg { padding: 6px 14px; font-size: var(--text-sm); }
+.badge--lg .material-symbols-outlined { font-size: 16px; }
 .badge--neutral { background: var(--c-neutral-bg); color: var(--c-neutral); }
 .badge--success { background: var(--c-success-bg); color: var(--c-success); }
 .badge--warning { background: var(--c-warning-bg); color: var(--c-warning); }

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -927,6 +927,26 @@ html.dark .badge-finalizado  { background: rgba(34, 197, 94, 0.20); color: #86EF
 .btn-tertiary:active { transform: scale(0.98); }
 .btn-tertiary:disabled { opacity: 0.5; cursor: not-allowed; }
 
+/* ── Square icon-action button (toolbars, table row actions) ── */
+.btn-icon {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: 12px;
+  border: 1px solid var(--c-separator);
+  background: transparent;
+  color: var(--c-gray);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
+}
+.btn-icon:hover  { transform: translateY(-1px); }
+.btn-icon:active { transform: scale(0.95); }
+.btn-icon:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-icon .material-symbols-outlined { font-size: 20px; }
+
 /* ── Badge — one component, variants by category (estado / rol / organización) ── */
 .badge {
   display: inline-flex;
@@ -1025,6 +1045,7 @@ html.dark {
 }
 html.dark .t-body { color: #C9C2D6; }
 html.dark .btn-tertiary:hover { background: rgba(255, 255, 255, 0.07); color: var(--c-title); }
+html.dark .btn-icon { border-color: rgba(255, 255, 255, 0.12); color: #A89FB3; }
 html.dark .badge--outline { border-color: rgba(255, 255, 255, 0.16); color: var(--c-label); }
 html.dark .stat-card { background: rgba(27, 21, 41, 0.94); border-color: rgba(255, 255, 255, 0.07); }
 html.dark .stat-card__icon { background: rgba(255, 90, 31, 0.14); color: #FFB088; }

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -258,13 +258,13 @@ textarea {
   font-weight: 700;
   border: none;
   border-radius: var(--radius-btn);
-  box-shadow: 0 8px 18px var(--c-orange-glow);
+  box-shadow: 0 4px 14px rgba(255, 90, 31, 0.25);
   cursor: pointer;
   transition: transform 0.15s, box-shadow 0.15s, opacity 0.2s;
 }
 .btn-primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(255, 90, 31, 0.45);
+  box-shadow: 0 8px 20px rgba(255, 90, 31, 0.32);
 }
 .btn-primary:active { transform: scale(0.98); }
 .btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
@@ -360,7 +360,16 @@ textarea {
 }
 .step-pill.active {
   background: var(--c-orange-light);
-  color: var(--c-orange);
+  color: var(--c-orange-hover);
+  box-shadow: inset 0 0 0 1.5px rgba(255, 90, 31, 0.35);
+}
+/* Completed step (multi-step capture flow) */
+.step-pill.done {
+  color: var(--c-success);
+}
+.step-pill.done .step-pill-num {
+  background: var(--c-success);
+  color: #fff;
 }
 .step-pill-num {
   width: 22px;
@@ -454,7 +463,7 @@ textarea {
 
 /* ── Button press scale ── */
 .btn-primary:active { transform: scale(0.98); }
-.btn-primary:hover  { box-shadow: 0 12px 26px rgba(255, 90, 31, 0.45); }
+.btn-primary:hover  { box-shadow: 0 8px 20px rgba(255, 90, 31, 0.32); }
 
 /* ── Table / list row hover ── */
 tr, li {

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -1043,6 +1043,67 @@ html.dark .badge-finalizado  { background: rgba(34, 197, 94, 0.20); color: #86EF
 }
 .sr-check { display: inline-block; animation: sr-check-pop 0.4s cubic-bezier(0.22, 1.4, 0.36, 1) both; }
 
+/* ── Tabs (modal detail, org panels) — underline-active, reusable ── */
+.modal-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1.5px solid #e2e8f0;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 5;
+  overflow-x: auto;
+}
+.modal-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 9px 11px;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--c-gray);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1.5px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+}
+.modal-tab .material-symbols-outlined { font-size: 16px; }
+.modal-tab:hover { color: var(--c-title); }
+.modal-tab.active { color: var(--c-orange-hover); border-bottom-color: var(--c-orange); }
+
+/* ── Scroll-more indicator (bottom fade + bouncing chevron) ── */
+.modal-scroll-hint {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 44px;
+  pointer-events: none;
+  border-radius: 0 0 1rem 1rem;
+  background: linear-gradient(to top, rgba(255, 255, 255, 0.96) 15%, rgba(255, 255, 255, 0));
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-bottom: 5px;
+}
+.modal-scroll-hint::after {
+  content: 'expand_more';
+  font-family: 'Material Symbols Outlined';
+  font-size: 20px;
+  color: var(--c-gray);
+  animation: sr-bounce 1.4s ease-in-out infinite;
+}
+@keyframes sr-bounce { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(3px); } }
+
+html.dark .modal-tabs { background: #1B1529; border-bottom-color: rgba(255, 255, 255, 0.10); }
+html.dark .modal-tab.active { color: #FFB088; }
+html.dark .modal-scroll-hint { background: linear-gradient(to top, rgba(27, 21, 41, 0.96) 15%, rgba(27, 21, 41, 0)); }
+
+@media (prefers-reduced-motion: reduce) { .modal-scroll-hint::after { animation: none; } }
+
 /* ── Dark-mode treatment for Fase 0 components ── */
 html.dark {
   --c-success-bg: rgba(34, 197, 94, 0.18);  --c-success: #86EFAC;

--- a/front/login.html
+++ b/front/login.html
@@ -44,7 +44,7 @@
     </div>
 
     <!-- Separator 1 -->
-    <div class="hidden md:flex brand-separator mx-8 lg:mx-10" style="height:80px;"></div>
+    <div class="hidden md:flex brand-separator mx-8 lg:mx-10" style="height:48px;"></div>
 
     <!-- Hope Haven -->
     <div class="flex items-center justify-center overflow-hidden">
@@ -55,7 +55,7 @@
     </div>
 
     <!-- Separator 2 -->
-    <div class="hidden md:flex brand-separator mx-8 lg:mx-10" style="height:80px;"></div>
+    <div class="hidden md:flex brand-separator mx-8 lg:mx-10" style="height:48px;"></div>
 
     <!-- Rotary 200 -->
     <div class="flex items-center justify-center overflow-hidden">

--- a/front/perfil-organizacion.html
+++ b/front/perfil-organizacion.html
@@ -118,17 +118,26 @@
         </div>
 
         <div class="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div class="rounded-xl p-5 bg-purple-50/70 border border-purple-100">
-            <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Capturas totales</p>
-            <p class="text-3xl font-bold mt-1" style="color: var(--c-title);" id="stat-capturas" data-countup>0</p>
+          <div class="stat-card">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">content_paste</span></div>
+            <div class="stat-card__body">
+              <span class="stat-card__value" id="stat-capturas" data-countup>0</span>
+              <span class="stat-card__label">Capturas totales</span>
+            </div>
           </div>
-          <div class="bg-green-50 rounded-xl p-5 border border-green-100">
-            <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Completados</p>
-            <p class="text-3xl font-bold text-green-600 mt-1" id="stat-completados" data-countup>0</p>
+          <div class="stat-card stat-card--success">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">task_alt</span></div>
+            <div class="stat-card__body">
+              <span class="stat-card__value" id="stat-completados" data-countup>0</span>
+              <span class="stat-card__label">Completados</span>
+            </div>
           </div>
-          <div class="bg-amber-50 rounded-xl p-5 border border-amber-100">
-            <p class="text-xs font-semibold uppercase tracking-wider text-slate-500">Este mes</p>
-            <p class="text-3xl font-bold text-amber-600 mt-1" id="stat-this-month" data-countup>0</p>
+          <div class="stat-card stat-card--info">
+            <div class="stat-card__icon"><span class="material-symbols-outlined">calendar_month</span></div>
+            <div class="stat-card__body">
+              <span class="stat-card__value" id="stat-this-month" data-countup>0</span>
+              <span class="stat-card__label">Este mes</span>
+            </div>
           </div>
         </div>
       </div>
@@ -433,7 +442,7 @@
               <p class="text-sm font-semibold text-slate-900 truncate">${_esc(l.nombre)}</p>
               <p class="text-xs text-slate-500 truncate">${_esc(l.email)}</p>
             </div>
-            <span class="text-xs font-medium text-amber-700 bg-amber-50 rounded-full px-2.5 py-0.5">Líder</span>
+            <span class="badge badge--brand">Líder</span>
           </div>
         `).join('');
       }
@@ -450,7 +459,7 @@
               <p class="text-sm font-semibold text-slate-900 truncate">${_esc(m.nombre)}</p>
               <p class="text-xs text-slate-500 truncate">${_esc(m.email)}</p>
             </div>
-            <span class="text-xs font-medium text-blue-700 bg-blue-50 rounded-full px-2.5 py-0.5">Miembro</span>
+            <span class="badge badge--info">Miembro</span>
           </div>
         `).join('');
       }
@@ -487,7 +496,7 @@
               <p class="text-sm font-semibold text-slate-900 truncate">${_esc(l.nombre)}</p>
               <p class="text-xs text-slate-500 truncate">${_esc(l.email)}</p>
             </div>
-            <span class="text-xs font-medium text-amber-700 bg-amber-50 rounded-full px-2.5 py-0.5">Líder</span>
+            <span class="badge badge--brand">Líder</span>
           </div>
         `).join('');
       }
@@ -505,7 +514,7 @@
               <p class="text-sm font-semibold text-slate-900 truncate">${_esc(m.nombre)}</p>
               <p class="text-xs text-slate-500 truncate">${_esc(m.email)}</p>
             </div>
-            <span class="text-xs font-medium text-blue-700 bg-blue-50 rounded-full px-2.5 py-0.5">Miembro</span>
+            <span class="badge badge--info">Miembro</span>
           </div>
         `).join('');
       }
@@ -547,7 +556,9 @@
       days.push({ date: d, dateStr, count: lookup[dateStr] || 0 });
     }
 
-    const heatColors = ['#ebedf0','#9be9a8','#40c463','#30a14e','#216e39'];
+    // Brand-aligned orange ramp (matches perfil-capturista; ties heatmap to UI).
+    const _dark = document.documentElement.classList.contains('dark');
+    const heatColors = [_dark ? '#2A2340' : '#F0E7E2', '#FFD3BE', '#FF9E70', '#FF6A2C', _dark ? '#FF5A1F' : '#E8410A'];
     let svg = `<svg width="${svgW}" height="${svgH}" xmlns="http://www.w3.org/2000/svg">`;
     const months = ['Ene','Feb','Mar','Abr','May','Jun','Jul','Ago','Sep','Oct','Nov','Dic'];
     let lastMonth = -1;

--- a/front/perfil-organizacion.html
+++ b/front/perfil-organizacion.html
@@ -69,8 +69,6 @@
   }
   .heatmap-cell { width: 12px; height: 12px; border-radius: 3px; }
   .heatmap-month { font-size: 10px; fill: #94a3b8; }
-  .tab-btn { cursor: pointer; color: #94a3b8; padding-bottom: 4px; font-weight: 600; transition: all 0.2s; }
-  .tab-btn.active { color: var(--c-orange); border-bottom: 2px solid var(--c-orange); font-weight: 700; }
   .tab-content { display: none; }
   .tab-content.active { display: block; }
 </style>
@@ -188,34 +186,36 @@
         <h2 class="text-base font-semibold text-slate-800">Capturar como voluntario</h2>
       </div>
       <form id="guest-form" class="px-6 py-5 space-y-4" novalidate>
-        <div class="space-y-2">
-          <label class="block text-sm font-semibold text-slate-700" for="guest-nombre">
-            Nombre del voluntario <span class="text-red-400">*</span>
-          </label>
-          <div class="relative">
-            <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 text-xl pointer-events-none">badge</span>
-            <input
-              id="guest-nombre" name="guest-nombre" type="text" autocomplete="off"
-              placeholder="Ej: María López"
-              minlength="2" maxlength="120"
-              class="w-full pl-12 pr-4 py-4 text-sm"
-            />
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div class="space-y-2">
+            <label class="block text-sm font-semibold text-slate-700" for="guest-nombre">
+              Nombre del voluntario <span class="text-red-400">*</span>
+            </label>
+            <div class="relative">
+              <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 text-xl pointer-events-none">badge</span>
+              <input
+                id="guest-nombre" name="guest-nombre" type="text" autocomplete="off"
+                placeholder="Ej: María López"
+                minlength="2" maxlength="120"
+                class="w-full pl-12 pr-4 py-3 text-sm"
+              />
+            </div>
+            <p id="guest-nombre-error" class="hidden text-red-600 text-sm" role="alert"></p>
           </div>
-          <p id="guest-nombre-error" class="hidden text-red-600 text-sm" role="alert"></p>
-        </div>
 
-        <div class="space-y-2">
-          <label class="block text-sm font-semibold text-slate-700" for="guest-contacto">
-            Teléfono de contacto <span class="text-red-400">*</span>
-          </label>
-          <div class="relative">
-            <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 text-xl pointer-events-none">call</span>
-            <input
-              id="guest-contacto" name="guest-contacto" type="tel" autocomplete="off"
-              placeholder="4771234567"
-              maxlength="10" pattern="[0-9]{10}" required
-              class="w-full pl-12 pr-4 py-4 text-sm"
-            />
+          <div class="space-y-2">
+            <label class="block text-sm font-semibold text-slate-700" for="guest-contacto">
+              Teléfono de contacto <span class="text-red-400">*</span>
+            </label>
+            <div class="relative">
+              <span class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 text-xl pointer-events-none">call</span>
+              <input
+                id="guest-contacto" name="guest-contacto" type="tel" autocomplete="off"
+                placeholder="4771234567"
+                maxlength="10" pattern="[0-9]{10}" required
+                class="w-full pl-12 pr-4 py-3 text-sm"
+              />
+            </div>
           </div>
         </div>
 
@@ -223,7 +223,7 @@
 
         <button
           id="btn-continuar-captura" type="submit"
-          class="btn-primary w-full py-4 rounded-xl flex items-center justify-center gap-2 group disabled:opacity-60 disabled:cursor-not-allowed"
+          class="btn-primary w-full py-3.5 rounded-xl flex items-center justify-center gap-2 group disabled:opacity-60 disabled:cursor-not-allowed"
         >
           <span class="material-symbols-outlined text-xl group-hover:translate-x-1 transition-transform">arrow_forward</span>
           <span>Comenzar Captura</span>
@@ -239,9 +239,15 @@
 
     <!-- Tabs: Beneficiarios / Voluntarios (org members only — hidden for visitors) -->
     <div id="org-activity-card" class="card rise rise-4 overflow-hidden">
-      <div class="px-6 py-3 border-b border-slate-100 flex items-center gap-6">
-        <button class="tab-btn active text-sm font-semibold" data-tab="tab-beneficiarios">Beneficiarios</button>
-        <button class="tab-btn text-sm font-semibold" data-tab="tab-voluntarios">Voluntarios</button>
+      <div class="modal-tabs px-6">
+        <button class="modal-tab active" data-tab="tab-beneficiarios">
+          <span class="material-symbols-outlined">assignment_ind</span><span>Beneficiarios</span>
+          <span class="badge badge--neutral" id="tab-count-ben">0</span>
+        </button>
+        <button class="modal-tab" data-tab="tab-voluntarios">
+          <span class="material-symbols-outlined">diversity_3</span><span>Voluntarios</span>
+          <span class="badge badge--neutral" id="tab-count-vol">0</span>
+        </button>
       </div>
 
       <!-- Beneficiarios tab -->
@@ -249,7 +255,6 @@
         <div class="px-6 py-4 border-b border-slate-100 flex items-center gap-3">
           <span class="material-symbols-outlined text-xl" style="color: var(--c-orange);">assignment</span>
           <h2 class="text-base font-semibold text-slate-800">Capturas de la organización</h2>
-          <span id="count-capturas" class="text-xs font-bold text-ug-orange-pure bg-orange-50 rounded-full px-2.5 py-0.5">0</span>
         </div>
         <div id="beneficiarios-list" class="divide-y divide-slate-100">
           <div id="loading-state" class="px-6 py-10" data-thinking="Reuniendo capturas"></div>
@@ -380,9 +385,9 @@
   });
 
   // ── Tab switching ───────────────────────────────────────────────────────────
-  document.querySelectorAll('.tab-btn').forEach(btn => {
+  document.querySelectorAll('.modal-tab').forEach(btn => {
     btn.addEventListener('click', function () {
-      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.modal-tab').forEach(b => b.classList.remove('active'));
       document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
       this.classList.add('active');
       document.getElementById(this.dataset.tab).classList.add('active');
@@ -601,7 +606,7 @@
       if (!res.ok) throw new Error('HTTP ' + res.status);
       const capturas = await res.json();
       loading.classList.add('hidden');
-      document.getElementById('count-capturas').textContent = capturas.length;
+      document.getElementById('tab-count-ben').textContent = capturas.length;
 
       if (capturas.length === 0) {
         empty.classList.remove('hidden');
@@ -650,6 +655,7 @@
       if (!res.ok) throw new Error('HTTP ' + res.status);
       const voluntarios = await res.json();
       document.getElementById('vol-loading').classList.add('hidden');
+      document.getElementById('tab-count-vol').textContent = voluntarios.length;
 
       if (voluntarios.length === 0) {
         body.innerHTML = '<div class="px-6 py-10 text-center text-slate-400 text-sm">No hay voluntarios registrados.</div>';


### PR DESCRIPTION
## Resumen

Unificación visual y de accesibilidad sobre `branch-beta03`, cubriendo la auditoría de jerarquía/consistencia completa. Capa **aditiva** en `theme.css` (no se modificó ningún selector existente) + adopción por pantalla.

## Fases

- **Fase 0 — Fundaciones** (`theme.css`): escala tipográfica, escala de color semántica AA, jerarquía de botones (primary/secondary/**tertiary**/**icon**), componente `.badge` con variantes, `.stat-card`, `.modal-tab`, skeleton/microinteracciones. Todo con dark-mode + `prefers-reduced-motion`. Style guide vivo en `front/_styleguide.html` (`/_styleguide.html`).
- **Fase 1 — Adopción**: perfil-capturista, perfil-organizacion, admin-usuarios, admin-beneficiarios, vista_tecnicos (stat-cards, badges de escala fija, heatmap de marca, resúmenes superiores).
- **Fase 2 — Pulido por pantalla**: login (logos normalizados + overlay de video), stepper + jerarquía de CTA (sombra global atenuada), admin-regiones (disabled explícito), **modal técnico con tabs + indicador de scroll**, organización (tabs unificados + form 2 columnas), tabla admin-usuarios responsive.
- **Fase 3 — Formularios + movimiento**: cleanup de stragglers en socioeconomico/tecnica/gestion (ya estaban adoptados); animación de entrada en resúmenes. (La capa de movimiento ya era rica vía `delight.js`.)
- **Fase 4 — Accesibilidad**: tabs con semántica `tablist` completa (aria-selected/tabpanel), botones de solo-icono con `aria-label` + `aria-hidden` en glifos, toggle de filtros con `aria-expanded`.

## Decisiones de producto aplicadas

- Sin desglose Completos/Borradores en resúmenes: **admin y técnico solo ven completos**.
- Tarjeta de bandeja técnica = "En proceso" (solicitudes técnicas iniciadas, no borradores de capturista).
- `_styleguide.html` queda como **documentación viva** del sistema.

## Verificación

- CSS balanceado; JS validado con `node --check`; todas las páginas sirven 200.
- Verificación visual (headless): style guide y login renderizan coherentes. Las pantallas con auth quedan para revisión con sesión real.
- Backend sin cambios.

## Notas

- Sin migraciones ni cambios de DB.
- Follow-up opcional: agregado backend `COUNT GROUP BY status` si se quisiera desglose por estado (hoy no aplica por la regla de visibilidad).