### PR TITLE
forms UX: componentes táctiles, búsqueda, pasos, validación en vivo

### DIFF
--- a/front/Admin-view/admin-regiones.html
+++ b/front/Admin-view/admin-regiones.html
@@ -31,8 +31,8 @@
 <script src="../assets/js/theme-toggle.js"></script>
 <script src="../assets/js/delight.js"></script>
 <script src="../assets/js/session-guard.js"></script>
-<script src="../assets/js/confirmation-modal.js"></script>
-<script src="../assets/js/mascot.js"></script>
+<script src="../assets/js/confirmation-modal.js?v=2"></script>
+<script src="../assets/js/mascot.js?v=2"></script>
 <link href="../assets/css/admin-regiones.css" rel="stylesheet"/>
   <style>
     /* Fixed gradient layer (same format as perfil-capturista) */

--- a/front/Admin-view/admin-regiones.html
+++ b/front/Admin-view/admin-regiones.html
@@ -32,6 +32,7 @@
 <script src="../assets/js/delight.js"></script>
 <script src="../assets/js/session-guard.js"></script>
 <script src="../assets/js/confirmation-modal.js"></script>
+<script src="../assets/js/mascot.js"></script>
 <link href="../assets/css/admin-regiones.css" rel="stylesheet"/>
   <style>
     /* Fixed gradient layer (same format as perfil-capturista) */

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -37,8 +37,8 @@
     <script src="../assets/js/theme-toggle.js"></script>
     <script src="../assets/js/delight.js"></script>
     <script src="../assets/js/session-guard.js"></script>
-    <script src="../assets/js/confirmation-modal.js"></script>
-    <script src="../assets/js/mascot.js"></script>
+    <script src="../assets/js/confirmation-modal.js?v=2"></script>
+    <script src="../assets/js/mascot.js?v=2"></script>
     <link href="../assets/css/admin-usuarios.css" rel="stylesheet" />
     <style>
     /* Fixed gradient layer (same format as perfil-capturista) */

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -38,6 +38,7 @@
     <script src="../assets/js/delight.js"></script>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/confirmation-modal.js"></script>
+    <script src="../assets/js/mascot.js"></script>
     <link href="../assets/css/admin-usuarios.css" rel="stylesheet" />
     <style>
     /* Fixed gradient layer (same format as perfil-capturista) */

--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -335,6 +335,17 @@
         window.location.href = "perfil-capturista.html";
       });
 
+      // Step-bar back links: warn before leaving with unsaved changes (no data loss)
+      document.querySelectorAll(".step-bar a.step-pill").forEach(function (a) {
+        a.addEventListener("click", async function (e) {
+          if (!formDirty) return;
+          e.preventDefault();
+          if (await AppConfirmation.confirmUnsavedNavigation()) {
+            window.location.href = a.getAttribute("href");
+          }
+        });
+      });
+
       // Role-gating: hide "Finalizar Registro" for non-capturista roles
       (function () {
         const rol = (sessionHeader?.rol || "").toLowerCase();

--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -329,6 +329,9 @@
         });
       })();
 
+      // Real-time validation: inline error below required text fields on blur.
+      SR_Validations.setupLiveRequired(document.querySelector("form"));
+
       // Volver al perfil sin cerrar sesión (logout lives in the profile)
       document.getElementById("btn-volver-perfil")?.addEventListener("click", async function () {
         if (formDirty && !(await AppConfirmation.confirmUnsavedNavigation())) return;

--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -73,17 +73,17 @@
     <!-- Step indicator -->
     <div class="w-full mt-4 step-bar">
       <div class="max-w-5xl mx-auto px-4 py-2.5 flex items-center gap-2">
-        <a href="socioeconomico.html" class="step-pill">
-          <div class="step-pill-num">1</div>
+        <a href="socioeconomico.html" class="step-pill done" title="Volver al estudio">
+          <div class="step-pill-num"><span class="material-symbols-outlined" style="font-size:14px" aria-hidden="true">check</span></div>
           <span>Estudio</span>
         </a>
         <div class="flex-1 h-0.5 bg-orange-200 rounded"></div>
-        <a href="tecnica.html" class="step-pill">
-          <div class="step-pill-num">2</div>
+        <a href="tecnica.html" class="step-pill done" title="Volver a la técnica">
+          <div class="step-pill-num"><span class="material-symbols-outlined" style="font-size:14px" aria-hidden="true">check</span></div>
           <span>Técnica</span>
         </a>
         <div class="flex-1 h-0.5 bg-orange-200 rounded"></div>
-        <div class="step-pill active">
+        <div class="step-pill active" aria-current="step">
           <div class="step-pill-num">3</div>
           <span>Gestión</span>
         </div>

--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -35,8 +35,8 @@
     <link href="../assets/css/theme.css" rel="stylesheet"/>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/theme-toggle.js"></script>
-    <script src="../assets/js/confirmation-modal.js"></script>
-    <script src="../assets/js/mascot.js"></script>
+    <script src="../assets/js/confirmation-modal.js?v=2"></script>
+    <script src="../assets/js/mascot.js?v=2"></script>
     <link href="../assets/css/gestion.css" rel="stylesheet" />
   </head>
   <body class="page-bg min-h-screen flex flex-col font-display" style="background: #FBF7F5;">

--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -233,7 +233,7 @@
         </div>
         <!-- Table -->
         <div id="table-wrap" class="hidden overflow-x-auto">
-          <table class="w-full text-sm min-w-[760px]">
+          <table class="bene-table w-full text-sm min-w-[760px]">
             <thead>
               <tr class="text-left text-xs text-slate-400 border-b border-slate-100">
                 <th class="font-semibold px-6 sm:px-8 py-3">Beneficiario</th>
@@ -520,7 +520,7 @@
           </span>
         </td>
         <td class="px-4 py-3.5">
-          <span class="${c.status === 'completo' ? 'bg-green-50 text-green-700 border-green-200' : 'bg-amber-50 text-amber-700 border-amber-200'} border text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 rounded-full whitespace-nowrap">
+          <span class="badge ${c.status === 'completo' ? 'badge--success' : 'badge--warning'}">
             ${c.status === 'completo' ? 'Completo' : c.status === 'borrador' ? 'Borrador' : _esc(c.status)}
           </span>
         </td>

--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -28,8 +28,8 @@
 </script>
 <link href="../assets/css/theme.css" rel="stylesheet"/>
 <script src="../assets/js/session-guard.js"></script>
-<script src="../assets/js/confirmation-modal.js"></script>
-<script src="../assets/js/mascot.js"></script>
+<script src="../assets/js/confirmation-modal.js?v=2"></script>
+<script src="../assets/js/mascot.js?v=2"></script>
 <script src="../assets/js/theme-toggle.js"></script>
 <script src="../assets/js/delight.js"></script>
 <style>

--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -29,6 +29,7 @@
 <link href="../assets/css/theme.css" rel="stylesheet"/>
 <script src="../assets/js/session-guard.js"></script>
 <script src="../assets/js/confirmation-modal.js"></script>
+<script src="../assets/js/mascot.js"></script>
 <script src="../assets/js/theme-toggle.js"></script>
 <script src="../assets/js/delight.js"></script>
 <style>

--- a/front/Capturista-view/seleccion-region.html
+++ b/front/Capturista-view/seleccion-region.html
@@ -181,6 +181,7 @@
 </footer>
 
 <script src="../assets/js/confirmation-modal.js"></script>
+<script src="../assets/js/mascot.js"></script>
 <script>
   // ── Auth guard (capturista and tecnico) ──────────────────────────────────────
   SessionGuard.requireRole(['capturista', 'tecnico', 'organizacion'], '../login.html');

--- a/front/Capturista-view/seleccion-region.html
+++ b/front/Capturista-view/seleccion-region.html
@@ -180,8 +180,8 @@
   </div>
 </footer>
 
-<script src="../assets/js/confirmation-modal.js"></script>
-<script src="../assets/js/mascot.js"></script>
+<script src="../assets/js/confirmation-modal.js?v=2"></script>
+<script src="../assets/js/mascot.js?v=2"></script>
 <script>
   // ── Auth guard (capturista and tecnico) ──────────────────────────────────────
   SessionGuard.requireRole(['capturista', 'tecnico', 'organizacion'], '../login.html');

--- a/front/Capturista-view/seleccion-region.html
+++ b/front/Capturista-view/seleccion-region.html
@@ -42,7 +42,7 @@
       </div>
       <div>
         <p class="text-[15px] font-bold" style="color: var(--c-title);">Selección de Región</p>
-        <p class="text-xs text-slate-500">Ecosistema VIDA UG</p>
+        <p class="text-xs text-slate-500">Configuración · Paso 1 de 2</p>
       </div>
     </div>
     <div class="flex items-center gap-3">

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -2395,6 +2395,32 @@
         });
       })();
 
+      // Real-time validation: required text fields show an error below the field
+      // on blur if left empty, and clear it as soon as the user types. Errors
+      // appear inline (no browser pop-ups). Radios/searchable selects keep their
+      // own UX and are validated on submit.
+      (function () {
+        const formEl = document.querySelector("form");
+        if (!formEl) return;
+        const fields = formEl.querySelectorAll(
+          'input[required]:not([type="radio"]):not([type="checkbox"]), textarea[required]'
+        );
+        fields.forEach(function (field) {
+          const name = field.getAttribute("name");
+          if (!name) return;
+          field.addEventListener("blur", function () {
+            if (!(field.value || "").trim()) {
+              SR_Validations.showFieldError(name, "Este campo es obligatorio");
+            } else {
+              SR_Validations.clearFieldError(name);
+            }
+          });
+          field.addEventListener("input", function () {
+            if ((field.value || "").trim()) SR_Validations.clearFieldError(name);
+          });
+        });
+      })();
+
       // Volver al perfil sin cerrar sesión (logout lives in the profile)
       document
         .getElementById("btn-volver-perfil")

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -35,7 +35,7 @@
     <link href="../assets/css/theme.css" rel="stylesheet"/>
     <script src="../assets/js/theme-toggle.js"></script>
     <script src="../assets/js/session-guard.js"></script>
-    <script src="../assets/js/confirmation-modal.js"></script>
+    <script src="../assets/js/confirmation-modal.js?v=2"></script>
     <link href="../assets/css/socioeconomico.css" rel="stylesheet" />
   </head>
   <body class="page-bg min-h-screen flex flex-col font-display" style="background: #FBF7F5;">

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -227,7 +227,7 @@
             </div>
             <div class="space-y-2">
               <label class="block text-sm font-semibold text-slate-700">Estado</label>
-              <select class="w-full" name="estado_codigo" id="estado_codigo" required aria-describedby="estado_codigo-error"></select>
+              <select class="w-full" name="estado_codigo" id="estado_codigo" required data-searchable aria-describedby="estado_codigo-error"></select>
               <p class="field-error hidden text-red-600 text-xs mt-1" id="estado_codigo-error" data-error-for="estado_codigo" role="alert"></p>
             </div>
             <div class="space-y-2">
@@ -238,6 +238,7 @@
                 id="ciudad"
                 required
                 disabled
+                data-searchable
                 aria-describedby="ciudad-error"
               >
                 <option value="">Selecciona un estado primero</option>
@@ -984,6 +985,7 @@
       </div>
     </div>
     <script src="../assets/js/validations.js"></script>
+    <script src="../assets/js/sr-select.js"></script>
     <script data-purpose="form-logic">
       const NIVEL_ESTUDIOS_CATALOG = [
         "NINGUNO", "PRIMARIA", "SECUNDARIA", "BACHILLERATO",
@@ -2223,6 +2225,9 @@
                   await loadMunicipiosCatalog();
                   renderMunicipiosSelect(b.estado_codigo, b.ciudad || "");
                 }
+                // Resync searchable-select triggers (setVal does not fire change)
+                document.getElementById("estado_codigo")?.dispatchEvent(new Event("sr:refresh"));
+                document.getElementById("ciudad")?.dispatchEvent(new Event("sr:refresh"));
                 setVal("telefonos", b.telefonos);
                 setVal("email", b.email);
                 const sexoEl = document.querySelector(`[name="sexo"][value="${b.sexo}"]`);

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -2395,31 +2395,9 @@
         });
       })();
 
-      // Real-time validation: required text fields show an error below the field
-      // on blur if left empty, and clear it as soon as the user types. Errors
-      // appear inline (no browser pop-ups). Radios/searchable selects keep their
-      // own UX and are validated on submit.
-      (function () {
-        const formEl = document.querySelector("form");
-        if (!formEl) return;
-        const fields = formEl.querySelectorAll(
-          'input[required]:not([type="radio"]):not([type="checkbox"]), textarea[required]'
-        );
-        fields.forEach(function (field) {
-          const name = field.getAttribute("name");
-          if (!name) return;
-          field.addEventListener("blur", function () {
-            if (!(field.value || "").trim()) {
-              SR_Validations.showFieldError(name, "Este campo es obligatorio");
-            } else {
-              SR_Validations.clearFieldError(name);
-            }
-          });
-          field.addEventListener("input", function () {
-            if ((field.value || "").trim()) SR_Validations.clearFieldError(name);
-          });
-        });
-      })();
+      // Real-time validation: inline error below required text fields on blur,
+      // cleared as the user types (no browser pop-ups).
+      SR_Validations.setupLiveRequired(document.querySelector("form"));
 
       // Volver al perfil sin cerrar sesión (logout lives in the profile)
       document

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -35,7 +35,7 @@
     <link href="../assets/css/theme.css" rel="stylesheet"/>
     <script src="../assets/js/theme-toggle.js"></script>
     <script src="../assets/js/session-guard.js"></script>
-    <script src="../assets/js/confirmation-modal.js"></script>
+    <script src="../assets/js/confirmation-modal.js?v=2"></script>
     <link href="../assets/css/tecnica.css" rel="stylesheet" />
   </head>
   <body class="page-bg min-h-screen flex flex-col font-display" style="background: #FBF7F5;">

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -1056,6 +1056,9 @@
         });
       })();
 
+      // Real-time validation: inline error below required text fields on blur.
+      SR_Validations.setupLiveRequired(document.querySelector("form"));
+
       // Volver al perfil sin cerrar sesión (logout lives in the profile)
       document.getElementById("btn-volver-perfil")?.addEventListener("click", async function () {
         if (formDirty && !(await AppConfirmation.confirmUnsavedNavigation())) return;

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -1062,6 +1062,17 @@
         window.location.href = "perfil-capturista.html";
       });
 
+      // Step-bar back links: warn before leaving with unsaved changes (no data loss)
+      document.querySelectorAll(".step-bar a.step-pill").forEach(function (a) {
+        a.addEventListener("click", async function (e) {
+          if (!formDirty) return;
+          e.preventDefault();
+          if (await AppConfirmation.confirmUnsavedNavigation()) {
+            window.location.href = a.getAttribute("href");
+          }
+        });
+      });
+
       // -- Setup padecimientos selection sync ------------------------------------
       function _setupDiagnosticoValidation() {
         const input = document.querySelector('[name="diagnostico"]');

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -72,12 +72,12 @@
     <!-- Step indicator -->
     <div class="w-full mt-4 step-bar">
       <div class="max-w-4xl mx-auto px-4 py-2.5 flex items-center gap-2">
-        <a href="socioeconomico.html" class="step-pill">
-          <div class="step-pill-num">1</div>
+        <a href="socioeconomico.html" class="step-pill done" title="Volver al estudio">
+          <div class="step-pill-num"><span class="material-symbols-outlined" style="font-size:14px" aria-hidden="true">check</span></div>
           <span>Estudio</span>
         </a>
         <div class="flex-1 h-0.5 bg-orange-200 rounded"></div>
-        <div class="step-pill active">
+        <div class="step-pill active" aria-current="step">
           <div class="step-pill-num">2</div>
           <span>Técnica</span>
         </div>

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -316,11 +316,11 @@
             <span class="stat-card__label">En esta página</span>
           </div>
         </div>
-        <div class="stat-card stat-card--warning">
-          <div class="stat-card__icon"><span class="material-symbols-outlined">edit_note</span></div>
+        <div class="stat-card stat-card--success">
+          <div class="stat-card__icon"><span class="material-symbols-outlined">file_download</span></div>
           <div class="stat-card__body">
-            <span class="stat-card__value" id="summary-borradores">0</span>
-            <span class="stat-card__label">En proceso (página)</span>
+            <span class="stat-card__value" id="summary-exportados">0</span>
+            <span class="stat-card__label">Exportados</span>
           </div>
         </div>
       </div>
@@ -1019,8 +1019,8 @@
         const byId = function (id) { return document.getElementById(id); };
         byId("summary-asignados").textContent = state.total;
         byId("summary-shown").textContent = state.items.length;
-        byId("summary-borradores").textContent =
-          state.items.filter(function (i) { return i.solicitud_status === "borrador"; }).length;
+        byId("summary-exportados").textContent =
+          state.items.filter(function (i) { return state.exportedIds.has(i.beneficiario_id); }).length;
       }
 
       // ═══════════════════════════════════════════════════════════════════════════

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -36,8 +36,8 @@
     <script src="../assets/js/theme-toggle.js"></script>
 <script src="../assets/js/delight.js"></script>
     <script src="../assets/js/session-guard.js"></script>
-    <script src="../assets/js/confirmation-modal.js"></script>
-    <script src="../assets/js/mascot.js"></script>
+    <script src="../assets/js/confirmation-modal.js?v=2"></script>
+    <script src="../assets/js/mascot.js?v=2"></script>
     <link href="../assets/css/vista-tecnicos.css" rel="stylesheet" />
     <style>
       /* Fixed gradient layer (same format as perfil-capturista) */

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -37,6 +37,7 @@
 <script src="../assets/js/delight.js"></script>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/confirmation-modal.js"></script>
+    <script src="../assets/js/mascot.js"></script>
     <link href="../assets/css/vista-tecnicos.css" rel="stylesheet" />
     <style>
       /* Fixed gradient layer (same format as perfil-capturista) */

--- a/front/_styleguide.html
+++ b/front/_styleguide.html
@@ -127,6 +127,31 @@
         </div>
       </section>
 
+      <!-- Collapsible -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Sección colapsable</h2>
+        <div style="display:flex; flex-direction:column; gap:0.75rem; max-width:420px;">
+          <div class="sr-collapse open">
+            <button type="button" class="sr-collapse__head" data-collapse-toggle aria-expanded="true">
+              <span>Justificación (abierta)</span>
+              <span class="material-symbols-outlined sr-collapse__chevron" aria-hidden="true">expand_more</span>
+            </button>
+            <div class="sr-collapse__body"><div class="sr-collapse__inner">
+              <p class="t-body" style="margin:0;">Contenido opcional visible. Se anima al colapsar/expandir.</p>
+            </div></div>
+          </div>
+          <div class="sr-collapse">
+            <button type="button" class="sr-collapse__head" data-collapse-toggle aria-expanded="false">
+              <span>Medidas técnicas (cerrada)</span>
+              <span class="material-symbols-outlined sr-collapse__chevron" aria-hidden="true">expand_more</span>
+            </button>
+            <div class="sr-collapse__body"><div class="sr-collapse__inner">
+              <p class="t-body" style="margin:0;">Oculto hasta que se necesita.</p>
+            </div></div>
+          </div>
+        </div>
+      </section>
+
       <!-- Skeleton + check -->
       <section class="card panel">
         <h2 class="t-section-title" style="margin-bottom: 1rem;">Microinteracciones</h2>
@@ -142,5 +167,6 @@
       </section>
     </div>
     <script src="assets/js/sr-select.js"></script>
+    <script src="assets/js/sr-collapse.js"></script>
   </body>
 </html>

--- a/front/_styleguide.html
+++ b/front/_styleguide.html
@@ -105,6 +105,28 @@
         </div>
       </section>
 
+      <!-- Searchable select -->
+      <section class="card panel">
+        <h2 class="t-section-title" style="margin-bottom: 1rem;">Select con búsqueda</h2>
+        <div style="max-width: 320px;">
+          <label class="t-label" for="sg-estado" style="display:block; margin-bottom:6px;">Estado</label>
+          <select id="sg-estado" data-searchable>
+            <option value="">— Selecciona —</option>
+            <option value="AGU">Aguascalientes</option>
+            <option value="BCN">Baja California</option>
+            <option value="CMX">Ciudad de México</option>
+            <option value="GUA">Guanajuato</option>
+            <option value="JAL">Jalisco</option>
+            <option value="NLE">Nuevo León</option>
+            <option value="OAX">Oaxaca</option>
+            <option value="PUE">Puebla</option>
+            <option value="QUE">Querétaro</option>
+            <option value="YUC">Yucatán</option>
+            <option value="ZAC">Zacatecas</option>
+          </select>
+        </div>
+      </section>
+
       <!-- Skeleton + check -->
       <section class="card panel">
         <h2 class="t-section-title" style="margin-bottom: 1rem;">Microinteracciones</h2>
@@ -119,5 +141,6 @@
         </p>
       </section>
     </div>
+    <script src="assets/js/sr-select.js"></script>
   </body>
 </html>

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -30,8 +30,8 @@
     </script>
     <link href="assets/css/theme.css" rel="stylesheet"/>
     <script src="assets/js/session-guard.js"></script>
-    <script src="assets/js/confirmation-modal.js"></script>
-    <script src="assets/js/mascot.js"></script>
+    <script src="assets/js/confirmation-modal.js?v=2"></script>
+    <script src="assets/js/mascot.js?v=2"></script>
     <script src="assets/js/theme-toggle.js"></script>
 <script src="assets/js/delight.js"></script>
     <script src="assets/js/sr-select.js"></script>

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -31,6 +31,7 @@
     <link href="assets/css/theme.css" rel="stylesheet"/>
     <script src="assets/js/session-guard.js"></script>
     <script src="assets/js/confirmation-modal.js"></script>
+    <script src="assets/js/mascot.js"></script>
     <script src="assets/js/theme-toggle.js"></script>
 <script src="assets/js/delight.js"></script>
     <script src="assets/js/sr-select.js"></script>

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -33,6 +33,7 @@
     <script src="assets/js/confirmation-modal.js"></script>
     <script src="assets/js/theme-toggle.js"></script>
 <script src="assets/js/delight.js"></script>
+    <script src="assets/js/sr-select.js"></script>
     <style>
       /* Filter panel */
       .filter-panel { transition: max-height 0.3s ease, opacity 0.2s ease; max-height: 0; opacity: 0; overflow: hidden; }
@@ -1228,6 +1229,7 @@
           _setupSillaPreviaConditionalField();
           _setupEstudioValidations();
           _setupMunicipiosCatalog();
+          if (window.SRSelect) SRSelect.enhanceAll(editContent);
           const delTutor2Btn = document.getElementById("btn-delete-tutor2");
           if (delTutor2Btn) {
             delTutor2Btn.addEventListener("click", function () {
@@ -1469,8 +1471,8 @@
           _field("num_ext", "Núm. Ext.", "text", { maxlength: 10 }) +
           _field("num_int", "Núm. Int.", "text", { maxlength: 10 }) +
           _field("colonia", "Colonia", "text", { maxlength: 120 }) +
-          '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Estado</label><select id="field-estado_codigo" name="estado_codigo" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3">' + estOpts + '</select></div>' +
-          '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Ciudad / Municipio</label><select id="field-ciudad" name="ciudad" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3" disabled><option value="">Selecciona un estado primero</option></select></div>' +
+          '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Estado</label><select id="field-estado_codigo" name="estado_codigo" data-searchable class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3">' + estOpts + '</select></div>' +
+          '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Ciudad / Municipio</label><select id="field-ciudad" name="ciudad" data-searchable class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3" disabled><option value="">Selecciona un estado primero</option></select></div>' +
           _field("telefonos", "Teléfono (10 dígitos)", "tel", { maxlength: 10 }) +
           '' +
           '</div>' +

--- a/front/assets/css/login.css
+++ b/front/assets/css/login.css
@@ -569,3 +569,29 @@ footer a:hover {
     animation: none;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   Dark mode — the warm-cream decorative layers (white/orange glows, header arcs,
+   waves) look muddy on a dark background. Kill the white glow and soften the rest
+   so the dark login reads clean instead of "asqueroso".
+   ═══════════════════════════════════════════════════════════════════════════ */
+html.dark .bg-glow-topleft { display: none; }            /* white glow — wrong on dark */
+html.dark .bg-glow-topright {
+  background: radial-gradient(ellipse at 70% 30%, rgba(255, 138, 77, 0.10) 0%, transparent 70%);
+}
+html.dark .bg-arc-topright { opacity: 0.30; }
+html.dark .brand-header::before { opacity: 0; }          /* faint left arc — drop it */
+html.dark .brand-header::after {
+  border-top-color: rgba(255, 138, 77, 0.22);
+  border-right-color: rgba(255, 138, 77, 0.10);
+}
+html.dark .wave-band,
+html.dark .wave-orange,
+html.dark .wave-purple { opacity: 0.40; }
+/* Logo chips: a softer, less stark surface than the bright off-white */
+html.dark .logo-vida-ug,
+html.dark .logo-hope-haven,
+html.dark .logo-rotary {
+  background: #ECE7F2;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.30);
+}

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -1157,6 +1157,13 @@ html.dark .modal-scroll-hint { background: linear-gradient(to top, rgba(27, 21, 
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 .sr-select__trigger:hover { border-color: var(--c-orange); }
+.sr-select__trigger--disabled,
+.sr-select__trigger:disabled {
+  background: #f1f5f9;
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+.sr-select__trigger--disabled:hover { border-color: var(--c-input-border); }
 .sr-select__trigger[aria-expanded="true"] {
   border-color: var(--c-orange);
   box-shadow: 0 0 0 3px rgba(241, 90, 36, 0.18);

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -1199,6 +1199,47 @@ html.dark .sr-select__pop { background: #1B1529; border-color: var(--c-input-bor
 html.dark .sr-select__opt { color: #C9C2D6; }
 @media (prefers-reduced-motion: reduce) { .sr-select__pop { animation: none; } }
 
+/* ── Collapsible section (optional form content) — see assets/js/sr-collapse.js ── */
+.sr-collapse {
+  border: 1px solid var(--c-separator);
+  border-radius: var(--radius-input);
+  overflow: hidden;
+}
+.sr-collapse__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg-soft-gray);
+  border: none;
+  cursor: pointer;
+  font-size: var(--text-body);
+  font-weight: 600;
+  color: var(--c-label);
+  transition: background-color 0.15s;
+}
+.sr-collapse__head:hover { background: var(--c-orange-light); }
+.sr-collapse__chevron { color: var(--c-gray); transition: transform 0.25s ease; flex-shrink: 0; }
+.sr-collapse.open .sr-collapse__chevron { transform: rotate(180deg); }
+.sr-collapse__body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease;
+}
+.sr-collapse.open .sr-collapse__body { grid-template-rows: 1fr; }
+.sr-collapse__inner { overflow: hidden; }
+.sr-collapse__inner > * { padding: 14px; }
+
+html.dark .sr-collapse { border-color: rgba(255, 255, 255, 0.10); }
+html.dark .sr-collapse__head { background: rgba(255, 255, 255, 0.04); }
+html.dark .sr-collapse__head:hover { background: rgba(255, 90, 31, 0.12); }
+@media (prefers-reduced-motion: reduce) {
+  .sr-collapse__body { transition: none; }
+  .sr-collapse__chevron { transition: none; }
+}
+
 /* ── Dark-mode treatment for Fase 0 components ── */
 html.dark {
   --c-success-bg: rgba(34, 197, 94, 0.18);  --c-success: #86EFAC;

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -1130,6 +1130,75 @@ html.dark .modal-scroll-hint { background: linear-gradient(to top, rgba(27, 21, 
 
 @media (prefers-reduced-motion: reduce) { .modal-scroll-hint::after { animation: none; } }
 
+/* ── Searchable select (combobox) — see assets/js/sr-select.js ── */
+.sr-select { position: relative; }
+.sr-select__native {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  min-height: 0 !important;
+  opacity: 0 !important;
+  pointer-events: none;
+}
+.sr-select__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 0 12px;
+  text-align: left;
+  background: var(--c-input-bg);
+  border: 1px solid var(--c-input-border);
+  border-radius: var(--radius-input);
+  color: #0f172a;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.sr-select__trigger:hover { border-color: var(--c-orange); }
+.sr-select__trigger[aria-expanded="true"] {
+  border-color: var(--c-orange);
+  box-shadow: 0 0 0 3px rgba(241, 90, 36, 0.18);
+}
+.sr-select__label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--text-body); }
+.sr-select__placeholder { color: var(--c-placeholder); }
+.sr-select__caret { font-size: 20px; color: var(--c-gray); flex-shrink: 0; }
+.sr-select__pop {
+  position: absolute;
+  z-index: 40;
+  left: 0;
+  right: 0;
+  top: calc(100% + 4px);
+  background: #fff;
+  border: 1px solid var(--c-input-border);
+  border-radius: var(--radius-input);
+  box-shadow: var(--shadow-card);
+  padding: 6px;
+  max-height: 280px;
+  display: flex;
+  flex-direction: column;
+  animation: fade-in 0.12s ease-out;
+}
+.sr-select__search { width: 100%; margin-bottom: 6px; }
+.sr-select__list { overflow-y: auto; }
+.sr-select__opt {
+  padding: 9px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: var(--text-body);
+  color: var(--c-label);
+}
+.sr-select__opt:hover,
+.sr-select__opt.active { background: var(--c-orange-light); color: var(--c-orange-hover); }
+.sr-select__opt[aria-selected="true"] { font-weight: 700; color: var(--c-orange-hover); }
+.sr-select__empty { padding: 12px; text-align: center; color: var(--c-gray); font-size: var(--text-sm); }
+
+html.dark .sr-select__trigger { background: var(--c-input-bg); color: #E8DFEE; }
+html.dark .sr-select__pop { background: #1B1529; border-color: var(--c-input-border); }
+html.dark .sr-select__opt { color: #C9C2D6; }
+@media (prefers-reduced-motion: reduce) { .sr-select__pop { animation: none; } }
+
 /* ── Dark-mode treatment for Fase 0 components ── */
 html.dark {
   --c-success-bg: rgba(34, 197, 94, 0.18);  --c-success: #86EFAC;

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -154,6 +154,32 @@ input[type="radio"]:checked {
   border-color: var(--c-orange) !important;
 }
 
+/* ── Touch-friendly radios/checkboxes inside capture forms ──
+   Scoped to <form> so admin table/list checkboxes keep their compact size.
+   22px control + a 40px-tall label so the whole label is an easy tap target. */
+form input[type="checkbox"],
+form input[type="radio"] {
+  width: 22px !important;
+  height: 22px !important;
+  min-width: 22px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+form input[type="radio"] { border-radius: 50%; }
+form label:has(> input[type="checkbox"]),
+form label:has(> input[type="radio"]) {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  cursor: pointer;
+}
+form label:has(> input[type="checkbox"]) > span,
+form label:has(> input[type="radio"]) > span {
+  font-size: var(--text-body);
+  color: var(--c-label);
+}
+
 /* ── File inputs: preserve orange file:// button, don't let height rules break them ── */
 input[type="file"] {
   background-color: transparent !important;

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -1100,6 +1100,22 @@ html.dark .badge-finalizado  { background: rgba(34, 197, 94, 0.20); color: #86EF
 .modal-tab:hover { color: var(--c-title); }
 .modal-tab.active { color: var(--c-orange-hover); border-bottom-color: var(--c-orange); }
 
+/* Detail modal (técnico): 4 tabs must fit the narrow modal without horizontal
+   scroll — equal-width, icon-over-label, compact. Scoped so page tabs (org)
+   keep their horizontal icon+label layout. */
+#modal-content .modal-tabs { gap: 0; overflow-x: visible; }
+#modal-content .modal-tab {
+  flex: 1 1 0;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 4px;
+  font-size: 11px;
+  line-height: 1.15;
+  text-align: center;
+  white-space: normal;
+}
+
 /* ── Scroll-more indicator (bottom fade + bouncing chevron) ── */
 .modal-scroll-hint {
   position: absolute;
@@ -1246,6 +1262,30 @@ html.dark .sr-collapse__head:hover { background: rgba(255, 90, 31, 0.12); }
   .sr-collapse__body { transition: none; }
   .sr-collapse__chevron { transition: none; }
 }
+
+/* ── Responsive captures table: stack rows as cards below md (no horizontal
+   scroll), keeping the status visible. Columns: 1 Beneficiario · 2 CURP ·
+   3 Fecha · 4 Capturista · 5 Estatus · 6 Acciones. ── */
+@media (max-width: 767px) {
+  .bene-table { min-width: 0 !important; }
+  .bene-table thead { display: none; }
+  .bene-table tbody tr {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid #eef0f3;
+  }
+  .bene-table tbody td { padding: 0 !important; white-space: normal !important; }
+  .bene-table tbody td:nth-child(1) { flex: 1 1 100%; }      /* beneficiario */
+  .bene-table tbody td:nth-child(2),                          /* curp */
+  .bene-table tbody td:nth-child(3) { flex: 0 0 auto; font-size: 12px; }  /* fecha */
+  .bene-table tbody td:nth-child(4) { display: none; }        /* capturista (own list) */
+  .bene-table tbody td:nth-child(5) { flex: 0 0 auto; }       /* estatus */
+  .bene-table tbody td:nth-child(6) { flex: 1 1 auto; text-align: right; }  /* acciones */
+}
+html.dark .bene-table tbody tr { border-bottom-color: rgba(255,255,255,0.07); }
 
 /* ── Dark-mode treatment for Fase 0 components ── */
 html.dark {

--- a/front/assets/js/confirmation-modal.js
+++ b/front/assets/js/confirmation-modal.js
@@ -140,6 +140,16 @@
       cancelText: "Cancelar",
       icon: "logout",
       tone: "orange",
+    }).then(function (ok) {
+      if (!ok) return false;
+      // Sparky waves goodbye, then the caller proceeds with the redirect.
+      return new Promise(function (resolve) {
+        if (window.SR_Mascot && SR_Mascot.showSuccess) {
+          SR_Mascot.showSuccess("¡Adiós! Te esperamos pronto", function () { resolve(true); });
+        } else {
+          resolve(true);
+        }
+      });
     });
   }
 

--- a/front/assets/js/sr-collapse.js
+++ b/front/assets/js/sr-collapse.js
@@ -1,0 +1,28 @@
+/* ============================================================================
+   sr-collapse.js — collapsible sections for optional form content.
+   Pure CSS animation (grid-template-rows 0fr→1fr); this only toggles state.
+   Delegated, so no per-element init is needed — just use the markup:
+
+     <div class="sr-collapse">                (add " open" to start expanded)
+       <button type="button" class="sr-collapse__head" data-collapse-toggle
+               aria-expanded="false">
+         <span>Justificación</span>
+         <span class="material-symbols-outlined sr-collapse__chevron"
+               aria-hidden="true">expand_more</span>
+       </button>
+       <div class="sr-collapse__body"><div class="sr-collapse__inner">
+         ... optional fields ...
+       </div></div>
+     </div>
+   ========================================================================== */
+(function () {
+  "use strict";
+  document.addEventListener("click", function (e) {
+    var head = e.target.closest("[data-collapse-toggle]");
+    if (!head) return;
+    var collapse = head.closest(".sr-collapse");
+    if (!collapse) return;
+    var open = collapse.classList.toggle("open");
+    head.setAttribute("aria-expanded", open ? "true" : "false");
+  });
+})();

--- a/front/assets/js/sr-select.js
+++ b/front/assets/js/sr-select.js
@@ -1,0 +1,172 @@
+/* ============================================================================
+   sr-select.js — searchable select (combobox) for long option lists.
+   Progressive enhancement over a native <select>: the native element stays in
+   the DOM (keeps its value, form submission and existing change listeners);
+   a searchable popup drives it. Auto-enhances any <select data-searchable>.
+
+   Usage:
+     <select id="estado" data-searchable> ... </select>
+     SRSelect.enhance(el)        // enhance one
+     SRSelect.enhanceAll(root)   // enhance all [data-searchable] under root
+   Dynamic options (e.g. municipios loaded on change) are picked up live.
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  function enhance(select) {
+    if (!select || select.dataset.srEnhanced) return;
+    select.dataset.srEnhanced = "1";
+
+    var wrap = document.createElement("div");
+    wrap.className = "sr-select";
+    select.parentNode.insertBefore(wrap, select);
+    wrap.appendChild(select);
+    select.classList.add("sr-select__native");
+    select.setAttribute("tabindex", "-1");
+    select.setAttribute("aria-hidden", "true");
+
+    var trigger = document.createElement("button");
+    trigger.type = "button";
+    trigger.className = "sr-select__trigger";
+    trigger.setAttribute("aria-haspopup", "listbox");
+    trigger.setAttribute("aria-expanded", "false");
+    if (select.id) trigger.setAttribute("aria-label", _labelFor(select));
+    wrap.appendChild(trigger);
+
+    var triggerLabel = document.createElement("span");
+    triggerLabel.className = "sr-select__label";
+    trigger.appendChild(triggerLabel);
+
+    var caret = document.createElement("span");
+    caret.className = "material-symbols-outlined sr-select__caret";
+    caret.setAttribute("aria-hidden", "true");
+    caret.textContent = "expand_more";
+    trigger.appendChild(caret);
+
+    var pop = document.createElement("div");
+    pop.className = "sr-select__pop hidden";
+    pop.setAttribute("role", "listbox");
+
+    var search = document.createElement("input");
+    search.type = "text";
+    search.className = "sr-select__search";
+    search.placeholder = "Buscar…";
+    search.setAttribute("aria-label", "Buscar opción");
+    search.autocomplete = "off";
+
+    var list = document.createElement("div");
+    list.className = "sr-select__list";
+
+    pop.appendChild(search);
+    pop.appendChild(list);
+    wrap.appendChild(pop);
+
+    var items = [];
+    var activeIdx = -1;
+
+    function _labelFor(sel) {
+      var lbl = sel.id && document.querySelector('label[for="' + sel.id + '"]');
+      return lbl ? lbl.textContent.trim() : "Seleccionar";
+    }
+
+    function syncLabel() {
+      var opt = select.options[select.selectedIndex];
+      var txt = opt ? opt.textContent.trim() : "";
+      var hasValue = !!select.value;
+      triggerLabel.textContent = txt || "Seleccionar…";
+      triggerLabel.classList.toggle("sr-select__placeholder", !hasValue);
+    }
+
+    function buildList(filter) {
+      list.innerHTML = "";
+      items = [];
+      var f = (filter || "").trim().toLowerCase();
+      Array.prototype.forEach.call(select.options, function (opt) {
+        var label = opt.textContent.trim();
+        if (f && label.toLowerCase().indexOf(f) === -1) return;
+        var el = document.createElement("div");
+        el.className = "sr-select__opt";
+        el.setAttribute("role", "option");
+        el.textContent = label;
+        if (opt.value === select.value && opt.value !== "") {
+          el.setAttribute("aria-selected", "true");
+        }
+        el.addEventListener("mousedown", function (e) {
+          e.preventDefault();
+          choose(opt.value);
+        });
+        list.appendChild(el);
+        items.push({ value: opt.value, el: el });
+      });
+      if (items.length === 0) {
+        var empty = document.createElement("div");
+        empty.className = "sr-select__empty";
+        empty.textContent = "Sin resultados";
+        list.appendChild(empty);
+      }
+      activeIdx = -1;
+    }
+
+    function isOpen() { return !pop.classList.contains("hidden"); }
+
+    function open() {
+      if (select.disabled) return;
+      buildList("");
+      pop.classList.remove("hidden");
+      trigger.setAttribute("aria-expanded", "true");
+      search.value = "";
+      setTimeout(function () { search.focus(); }, 0);
+    }
+
+    function close() {
+      pop.classList.add("hidden");
+      trigger.setAttribute("aria-expanded", "false");
+    }
+
+    function choose(value) {
+      select.value = value;
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+      syncLabel();
+      close();
+      trigger.focus();
+    }
+
+    function setActive(idx) {
+      if (!items.length) return;
+      activeIdx = (idx + items.length) % items.length;
+      items.forEach(function (it, i) { it.el.classList.toggle("active", i === activeIdx); });
+      items[activeIdx].el.scrollIntoView({ block: "nearest" });
+    }
+
+    trigger.addEventListener("click", function () { isOpen() ? close() : open(); });
+    trigger.addEventListener("keydown", function (e) {
+      if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") { e.preventDefault(); open(); }
+    });
+    search.addEventListener("input", function () { buildList(search.value); });
+    search.addEventListener("keydown", function (e) {
+      if (e.key === "ArrowDown") { e.preventDefault(); setActive(activeIdx + 1); }
+      else if (e.key === "ArrowUp") { e.preventDefault(); setActive(activeIdx - 1); }
+      else if (e.key === "Enter") { e.preventDefault(); if (activeIdx >= 0) choose(items[activeIdx].value); }
+      else if (e.key === "Escape") { e.preventDefault(); close(); trigger.focus(); }
+    });
+    document.addEventListener("click", function (e) { if (!wrap.contains(e.target)) close(); });
+
+    // Keep the trigger label in sync when value changes or options repopulate
+    select.addEventListener("change", syncLabel);
+    new MutationObserver(syncLabel).observe(select, { childList: true });
+
+    syncLabel();
+  }
+
+  function enhanceAll(root) {
+    (root || document).querySelectorAll("select[data-searchable]").forEach(enhance);
+  }
+
+  window.SRSelect = { enhance: enhance, enhanceAll: enhanceAll };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () { enhanceAll(); });
+  } else {
+    enhanceAll();
+  }
+})();

--- a/front/assets/js/sr-select.js
+++ b/front/assets/js/sr-select.js
@@ -151,11 +151,25 @@
     });
     document.addEventListener("click", function (e) { if (!wrap.contains(e.target)) close(); });
 
-    // Keep the trigger label in sync when value changes or options repopulate
+    function syncDisabled() {
+      trigger.disabled = select.disabled;
+      trigger.classList.toggle("sr-select__trigger--disabled", select.disabled);
+      if (select.disabled) close();
+    }
+
+    // Keep the trigger in sync when value/options/disabled change (incl. async
+    // population like municipios, and enable/disable on estado selection)
     select.addEventListener("change", syncLabel);
-    new MutationObserver(syncLabel).observe(select, { childList: true });
+    // Forms that set .value programmatically (no native change) can dispatch
+    // a "sr:refresh" event to resync the trigger.
+    select.addEventListener("sr:refresh", function () { syncLabel(); syncDisabled(); });
+    new MutationObserver(function () { syncLabel(); syncDisabled(); }).observe(
+      select,
+      { childList: true, attributes: true, attributeFilter: ["disabled"] }
+    );
 
     syncLabel();
+    syncDisabled();
   }
 
   function enhanceAll(root) {

--- a/front/assets/js/validations.js
+++ b/front/assets/js/validations.js
@@ -581,6 +581,30 @@
     }
   }
 
+  // Real-time required validation: text-like fields show an inline error below
+  // the field on blur when required+empty, and clear it as the user types.
+  // Checks `.required` at blur time so dynamically-required fields are covered.
+  function setupLiveRequired(formEl) {
+    if (!formEl) return;
+    const fields = formEl.querySelectorAll(
+      'input:not([type="radio"]):not([type="checkbox"]):not([type="hidden"]):not([type="file"]), textarea'
+    );
+    fields.forEach((field) => {
+      const name = field.getAttribute("name");
+      if (!name) return;
+      field.addEventListener("blur", () => {
+        if (field.required && !(field.value || "").trim()) {
+          showFieldError(name, "Este campo es obligatorio");
+        } else {
+          clearFieldError(name);
+        }
+      });
+      field.addEventListener("input", () => {
+        if ((field.value || "").trim()) clearFieldError(name);
+      });
+    });
+  }
+
   function clearAllFieldErrors(formEl) {
     formEl.querySelectorAll(".field-error").forEach((el) => {
       el.classList.add("hidden");
@@ -780,6 +804,7 @@
     validateHTML5Constraints,
     showFieldError,
     clearFieldError,
+    setupLiveRequired,
     clearAllFieldErrors,
     formatBackendError,
     sanitizeMoneyInput,

--- a/front/perfil-organizacion.html
+++ b/front/perfil-organizacion.html
@@ -29,6 +29,7 @@
 <link href="assets/css/theme.css" rel="stylesheet"/>
 <script src="assets/js/session-guard.js"></script>
 <script src="assets/js/confirmation-modal.js"></script>
+<script src="assets/js/mascot.js"></script>
 <script src="assets/js/theme-toggle.js"></script>
 <script src="assets/js/delight.js"></script>
 <style>

--- a/front/perfil-organizacion.html
+++ b/front/perfil-organizacion.html
@@ -28,8 +28,8 @@
 </script>
 <link href="assets/css/theme.css" rel="stylesheet"/>
 <script src="assets/js/session-guard.js"></script>
-<script src="assets/js/confirmation-modal.js"></script>
-<script src="assets/js/mascot.js"></script>
+<script src="assets/js/confirmation-modal.js?v=2"></script>
+<script src="assets/js/mascot.js?v=2"></script>
 <script src="assets/js/theme-toggle.js"></script>
 <script src="assets/js/delight.js"></script>
 <style>


### PR DESCRIPTION
## Resumen

Mejoras de UX en los formularios, **stacked sobre #134** (sistema de diseño). La base es `design/fase-0-foundations`, así que este PR muestra solo los cambios de formularios. Cubre los 7 puntos de la auditoría de formularios.

> Mergear #134 primero; luego este se retargetea/rebasa a `branch-beta03`.

## Capa A — componentes reutilizables
- **Radios/checkboxes táctiles** (`theme.css`, scoped a `form`): control 22px + label tap-target de 40px; tablas admin intactas.
- **`SRSelect`** (`assets/js/sr-select.js`): combobox con búsqueda sobre un `<select>` nativo (conserva valor, submit y listeners), teclado, ARIA listbox, opciones dinámicas (municipios) y sync de disabled. `data-searchable` para auto-mejora.
- **`.sr-collapse`** (`assets/js/sr-collapse.js`): sección colapsable con animación CSS (grid-rows), toggle delegado, aria-expanded.

## Capa B — cableado por formulario
- **Validación en tiempo real** (`SR_Validations.setupLiveRequired`): error inline bajo el campo en blur, se limpia al escribir; en socioeconomico, tecnica y gestion.
- **Searchable estado/municipio**: socioeconomico + modal de edición de admin-beneficiarios.
- **Pasos**: estados `done` (check) en la barra, "Paso X de N", y guard de back-nav (no perder datos al volver a un paso).
- Confirmado ya existente: disabled-coherente (`como_obtuvo`), feedback de guardado (toast animado), ocultar secciones opcionales (checkbox).

## Ajustes de revisión (post-feedback)
- Capturista «beneficiarios registrados» en teléfono → cards responsive con estatus visible (estilo tabla admin).
- Modal técnico → 4 tabs entran sin scroll horizontal.
- Resumen técnico → "Exportados" en vez de "En proceso" (admin/técnico solo ven terminados).

## Verificación
- JS validado con `node --check` (incl. scripts inline extraídos); CSS balanceado; páginas sirviendo 200.
- Componentes nuevos verificados visualmente en `/_styleguide.html` (searchable-select abierto, colapsable). Pantallas con login verificadas por el usuario en el navegador.
- Sin cambios de backend ni DB.

## Follow-ups opcionales
- Extender searchable-select a otros catálogos largos (escuelas/puestos) cuando existan.