### PR TITLE
fix(design): resolver nits de review de #134/#135

### DIFF
--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -607,14 +607,13 @@
 
       svg += '</svg>';
 
+      // Legend swatches mirror _heatColor so the ramp stays consistent with the
+      // cells in both light and dark mode.
+      const _legendRamp = [0, 1, 3, 6, 12].map(_heatColor);
       const legendHtml = `
         <div class="flex items-center gap-2 mt-4 text-xs text-slate-400 justify-end">
           <span>Menos</span>
-          <span class="heatmap-cell inline-block bg-[#F0E7E2]"></span>
-          <span class="heatmap-cell inline-block bg-[#FFD3BE]"></span>
-          <span class="heatmap-cell inline-block bg-[#FF9E70]"></span>
-          <span class="heatmap-cell inline-block bg-[#FF6A2C]"></span>
-          <span class="heatmap-cell inline-block bg-[#E8410A]"></span>
+          ${_legendRamp.map((c) => `<span class="heatmap-cell inline-block" style="background:${c}"></span>`).join('')}
           <span>Más</span>
         </div>
       `;

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -1317,7 +1317,8 @@
         ];
         const nav = '<div class="modal-tabs" role="tablist" aria-label="Secciones del beneficiario">' + tabs.map(function (t, i) {
           return '<button class="modal-tab' + (i === 0 ? " active" : "") + '" data-tab="' + t.id + '" id="tab-' + t.id + '" role="tab"' +
-            ' aria-selected="' + (i === 0 ? "true" : "false") + '" aria-controls="panel-' + t.id + '">' +
+            ' aria-selected="' + (i === 0 ? "true" : "false") + '" aria-controls="panel-' + t.id + '"' +
+            ' tabindex="' + (i === 0 ? "0" : "-1") + '">' +
             '<span class="material-symbols-outlined" aria-hidden="true">' + t.icon + '</span><span>' + t.label + '</span></button>';
         }).join("") + "</div>";
         const panels = tabs.map(function (t, i) {
@@ -1326,23 +1327,37 @@
 
         modalContent.innerHTML = nav + '<div class="mt-4">' + panels + "</div>";
 
-        // Tab switching
-        modalContent.querySelectorAll(".modal-tab").forEach(function (btn) {
-          btn.addEventListener("click", function () {
-            const id = btn.dataset.tab;
-            modalContent.querySelectorAll(".modal-tab").forEach(function (b) {
-              const on = b === btn;
-              b.classList.toggle("active", on);
-              b.setAttribute("aria-selected", on ? "true" : "false");
-            });
-            modalContent.querySelectorAll(".modal-panel").forEach(function (p) {
-              const show = p.dataset.panel === id;
-              p.classList.toggle("hidden", !show);
-              if (show) { p.removeAttribute("hidden"); } else { p.setAttribute("hidden", ""); }
-            });
-            const body = document.getElementById("modal-body");
-            if (body) body.scrollTop = 0;
-            _updateModalScrollHint();
+        // Tab switching (click + WAI-ARIA keyboard: arrows/Home/End with roving tabindex)
+        const tabBtns = Array.prototype.slice.call(modalContent.querySelectorAll(".modal-tab"));
+        function activateTab(btn, focus) {
+          const id = btn.dataset.tab;
+          tabBtns.forEach(function (b) {
+            const on = b === btn;
+            b.classList.toggle("active", on);
+            b.setAttribute("aria-selected", on ? "true" : "false");
+            b.tabIndex = on ? 0 : -1;
+          });
+          modalContent.querySelectorAll(".modal-panel").forEach(function (p) {
+            const show = p.dataset.panel === id;
+            p.classList.toggle("hidden", !show);
+            if (show) { p.removeAttribute("hidden"); } else { p.setAttribute("hidden", ""); }
+          });
+          if (focus) btn.focus();
+          const body = document.getElementById("modal-body");
+          if (body) body.scrollTop = 0;
+          _updateModalScrollHint();
+        }
+        tabBtns.forEach(function (btn, i) {
+          btn.addEventListener("click", function () { activateTab(btn); });
+          btn.addEventListener("keydown", function (e) {
+            let next = -1;
+            if (e.key === "ArrowRight" || e.key === "ArrowDown") next = (i + 1) % tabBtns.length;
+            else if (e.key === "ArrowLeft" || e.key === "ArrowUp") next = (i - 1 + tabBtns.length) % tabBtns.length;
+            else if (e.key === "Home") next = 0;
+            else if (e.key === "End") next = tabBtns.length - 1;
+            if (next < 0) return;
+            e.preventDefault();
+            activateTab(tabBtns[next], true);
           });
         });
         _updateModalScrollHint();

--- a/front/assets/css/theme.css
+++ b/front/assets/css/theme.css
@@ -1132,7 +1132,7 @@ html.dark .badge-finalizado  { background: rgba(34, 197, 94, 0.20); color: #86EF
   padding-bottom: 5px;
 }
 .modal-scroll-hint::after {
-  content: 'expand_more';
+  content: '\e5cf'; /* expand_more codepoint — robust vs. CSS-content ligatures */
   font-family: 'Material Symbols Outlined';
   font-size: 20px;
   color: var(--c-gray);

--- a/front/assets/js/sr-select.js
+++ b/front/assets/js/sr-select.js
@@ -77,13 +77,18 @@
       triggerLabel.classList.toggle("sr-select__placeholder", !hasValue);
     }
 
+    // Fold case + strip diacritics so "queretaro" matches "Querétaro".
+    function _norm(s) {
+      return (s || "").toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+    }
+
     function buildList(filter) {
       list.innerHTML = "";
       items = [];
-      var f = (filter || "").trim().toLowerCase();
+      var f = _norm((filter || "").trim());
       Array.prototype.forEach.call(select.options, function (opt) {
         var label = opt.textContent.trim();
-        if (f && label.toLowerCase().indexOf(f) === -1) return;
+        if (f && _norm(label).indexOf(f) === -1) return;
         var el = document.createElement("div");
         el.className = "sr-select__opt";
         el.setAttribute("role", "option");


### PR DESCRIPTION
## Resumen

Resuelve los nits anotados durante el review de #134 (sistema visual) y #135 (forms UX). Todo aditivo, sin backend ni DB.

De los 8 nits, **4 eran reales** y se arreglaron; **3 eran falsos positivos** (verificados en código) y **1 es intencional**.

## Arreglados

| # | Fix | Archivo |
| - | --- | ------- |
| 5 | SRSelect: búsqueda insensible a acentos (`queretaro` matchea `Querétaro`) vía `normalize("NFD")` | `assets/js/sr-select.js` |
| 3 | Modal técnico: navegación por teclado WAI-ARIA completa en tabs (ArrowLeft/Right/Up/Down/Home/End + roving `tabindex`) | `Tecnico-view/vista_tecnicos.html` |
| 1 | Leyenda del heatmap dark-aware: se construye desde `_heatColor` en vez de hex claro hardcodeado (antes desincronizaba con las celdas en dark) | `Capturista-view/perfil-capturista.html` |
| 2 | `modal-scroll-hint` chevron con codepoint `\e5cf` en vez de ligature en CSS `content` (más robusto entre navegadores) | `assets/css/theme.css` |

## Descartados tras verificar

- **Tap-targets `label:has()`**: los radios están anidados en `<label>` → el target de 40px ya aplica.
- **`setupLiveRequired` primer form**: cada página tiene exactamente 1 `<form>` → correcto.
- **Overflow del popup en modal admin**: el popup vive en un contenedor `overflow-y:auto` → no se recorta invisible.
- **`_styleguide.html` en prod**: intencional (documentación viva, per #134).

## Verificación

- `node --check` en todo el JS tocado (incl. scripts inline extraídos de los HTML).
- CSS balanceado (337/337 llaves).
- Self-check del normalizador de acentos con 4 casos reales (Querétaro, León, Mérida, México) — pasa.
- Sin cambios de backend ni DB.