### PR TITLE
fix(frontend): persistir equipo solicitado

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -107,6 +107,7 @@ DDL = [
         id                          SERIAL PRIMARY KEY,
         beneficiario_id             INTEGER NOT NULL REFERENCES beneficiarios(id) ON DELETE RESTRICT,
         usuario_id                  INTEGER NOT NULL REFERENCES usuarios(id) ON DELETE RESTRICT,
+        equipo_solicitado           TEXT,
         entorno                     TEXT,
         control_tronco              TEXT,
         control_cabeza              TEXT,
@@ -229,6 +230,7 @@ DDL = [
     "ALTER TABLE usuarios ADD COLUMN IF NOT EXISTS avatar_url TEXT",
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE",
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS padecimiento TEXT",
+    "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS equipo_solicitado TEXT",
 ]
 
 

--- a/backend/migrations/0024_add_equipo_solicitado_to_solicitudes_tecnicas.sql
+++ b/backend/migrations/0024_add_equipo_solicitado_to_solicitudes_tecnicas.sql
@@ -1,0 +1,4 @@
+-- 0024_add_equipo_solicitado_to_solicitudes_tecnicas.sql
+
+ALTER TABLE public.solicitudes_tecnicas
+ADD COLUMN IF NOT EXISTS equipo_solicitado TEXT;

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -40,6 +40,7 @@ ese entorno.
 | `0021` | `curp_natural_key` |
 | `0022` | `unify_org_leadership_source` |
 | `0023` | `normalize_ciudad_municipio` |
+| `0024` | `add_equipo_solicitado_to_solicitudes_tecnicas` |
 
 ## Deprecación de legado
 

--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -113,6 +113,7 @@ class GuardarBorradorRequest(BaseModel):
     status: Optional[str] = "borrador"
 
     # ── Solicitud (técnica) ──
+    equipo_solicitado: Optional[str] = None
     entorno: Optional[str] = None
     control_tronco: Optional[str] = None
     control_cabeza: Optional[str] = None
@@ -657,19 +658,20 @@ def _create_borrador(
         solicitud_id = db.execute(
             """
             INSERT INTO solicitudes_tecnicas
-                (beneficiario_id, usuario_id, entorno, control_tronco, control_cabeza,
+                (beneficiario_id, usuario_id, equipo_solicitado, entorno, control_tronco, control_cabeza,
                  control_de_piernas, padecimiento, soporte_oxigeno,
                  altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura,
                  unidad_peso_captura, foto_url, entidad_solicitante, prioridad,
                  justificacion, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
                 beneficiario_id,
                 usuario.usuario_id,
+                body.equipo_solicitado,
                 body.entorno,
                 body.control_tronco,
                 body.control_cabeza,
@@ -895,6 +897,7 @@ def _patch_solicitud(db: _DBAdapter, body: GuardarBorradorRequest, solicitud_id:
     """Build and execute a partial UPDATE for solicitud."""
     fields: dict[str, any] = {}
     sol_mappings = [
+        ("equipo_solicitado", body.equipo_solicitado),
         ("entorno", body.entorno),
         ("control_tronco", body.control_tronco),
         ("control_cabeza", body.control_cabeza),

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -346,6 +346,7 @@ def _storage():
 
 class SolicitudCreateRequest(BaseModel):
     beneficiario_id: int
+    equipo_solicitado: Optional[str] = None
     entorno: str
     diagnostico: Optional[str] = None
     control_tronco: str
@@ -481,6 +482,7 @@ class SolicitudCreateResponse(BaseModel):
 
 
 class SolicitudUpdateRequest(BaseModel):
+    equipo_solicitado: Optional[str] = None
     entorno: Optional[str] = None
     diagnostico: Optional[str] = None
     control_tronco: Optional[str] = None
@@ -1115,18 +1117,19 @@ def crear_solicitud(
         solicitud_id = db.execute(
             """
             INSERT INTO solicitudes_tecnicas
-                (beneficiario_id, usuario_id, entorno, control_tronco, control_cabeza, control_de_piernas,
+                (beneficiario_id, usuario_id, equipo_solicitado, entorno, control_tronco, control_cabeza, control_de_piernas,
                  padecimiento,
                  soporte_oxigeno, altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura, unidad_peso_captura, foto_url,
                  entidad_solicitante, prioridad, justificacion, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
                 body.beneficiario_id,
                 usuario.usuario_id,
+                body.equipo_solicitado,
                 body.entorno,
                 body.control_tronco,
                 body.control_cabeza,

--- a/backend/tests/test_tecnica.py
+++ b/backend/tests/test_tecnica.py
@@ -44,6 +44,16 @@ class TestTecnicaRbac:
         assert get_response.status_code == 200
         assert get_response.json()["soporte_oxigeno"] is True
 
+    def test_equipo_solicitado_persiste(self, client, tecnico_headers, sample_estudio):
+        payload = _solicitud_payload(sample_estudio["beneficiario_id"])
+        payload["equipo_solicitado"] = "Silla de ruedas neurológica PCI"
+        create_response = client.post("/api/solicitudes", headers=tecnico_headers, json=payload)
+        assert create_response.status_code == 201
+        solicitud_id = create_response.json()["solicitud_id"]
+        get_response = client.get(f"/api/solicitudes/{solicitud_id}", headers=tecnico_headers)
+        assert get_response.status_code == 200
+        assert get_response.json()["equipo_solicitado"] == "Silla de ruedas neurológica PCI"
+
     def test_unidad_cm_no_convierte_en_borrador(self, client, tecnico_headers, sample_estudio):
         """Borradores must store measurement values verbatim (no unit conversion).
         Conversion to canonical units (inches/lb) happens only at final submission."""

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -911,6 +911,7 @@
               const toDisplayKg = (dbVal) => toDisplay(dbVal);
 
               // Set select fields
+              setVal("equipo_solicitado", data.equipo_solicitado);
               setVal("entorno", data.entorno);
               setVal("diagnostico", data.diagnostico);
               setVal("control_tronco", data.control_tronco);
@@ -994,6 +995,7 @@
               const el = document.querySelector(`[name="${name}"]`);
               if (el && val != null) el.value = val;
             };
+            setVal("equipo_solicitado", data.equipo_solicitado);
             setVal("entorno", data.entorno);
             setVal("diagnostico", data.diagnostico);
             setVal("control_tronco", data.control_tronco);
@@ -1969,6 +1971,7 @@
         };
 
         return {
+          equipo_solicitado: get("equipo_solicitado"),
           entorno: get("entorno"),
           diagnostico: toStrOrNull(get("diagnostico")),
           control_tronco: get("control_tronco"),
@@ -2177,6 +2180,7 @@
             comprobante_domicilio_url: draftSocio.estudio?.comprobante_domicilio_url || null,
             status: "borrador",
             // Solicitud (técnica - actual)
+            equipo_solicitado: tecnicaData.equipo_solicitado || null,
             entorno: tecnicaData.entorno || null,
             control_tronco: tecnicaData.control_tronco || null,
             control_cabeza: tecnicaData.control_cabeza || null,
@@ -2338,6 +2342,7 @@
 
         const payload = {
           beneficiario_id: beneficiarioId,
+          equipo_solicitado: get("equipo_solicitado") || null,
           entorno: get("entorno"),
           diagnostico: (get("diagnostico") || "").trim() || null,
           control_tronco: get("control_tronco"),

--- a/tests/test_tecnica_equipo_solicitado_frontend.py
+++ b/tests/test_tecnica_equipo_solicitado_frontend.py
@@ -1,0 +1,21 @@
+"""Contract tests for Equipo Solicitado persistence in tecnica.html."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TECNICA_FILE = ROOT / "front" / "Capturista-view" / "tecnica.html"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_equipo_solicitado_is_collected_sent_and_restored() -> None:
+    html = _read(TECNICA_FILE)
+
+    assert 'name="equipo_solicitado"' in html
+    assert 'equipo_solicitado: get("equipo_solicitado")' in html
+    assert 'equipo_solicitado: get("equipo_solicitado") || null' in html
+    assert 'equipo_solicitado: tecnicaData.equipo_solicitado || null' in html
+    assert 'setVal("equipo_solicitado", data.equipo_solicitado)' in html


### PR DESCRIPTION
## Linked Issue
Closes #69

Note: issue #69 is linked, but it currently does not have the `status:approved` label. If PR validation requires that label, this PR will need the issue to be approved before merge.

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Conecta el campo `equipo_solicitado` al guardado/restauración de `tecnica.html`.
- Persiste el campo en solicitudes técnicas y en el flujo de `guardar-borrador`.
- Agrega migración incremental y pruebas de contrato para evitar que el campo vuelva a quedar solo en HTML.

## Changes
| File | Change |
|------|--------|
| `front/Capturista-view/tecnica.html` | Lee, envía y restaura `equipo_solicitado` en borradores/localStorage y payloads. |
| `backend/routers/tecnica.py` | Acepta y guarda `equipo_solicitado` en POST/PATCH de solicitudes. |
| `backend/routers/guardar_borrador.py` | Incluye `equipo_solicitado` al crear/actualizar borradores. |
| `backend/migrations/0024_add_equipo_solicitado_to_solicitudes_tecnicas.sql` | Agrega la columna `equipo_solicitado` a `solicitudes_tecnicas`. |
| `backend/init_db.py` | Mantiene el bootstrap legacy alineado con la nueva columna. |
| `backend/tests/test_tecnica.py` | Cubre persistencia backend del campo. |
| `tests/test_tecnica_equipo_solicitado_frontend.py` | Cubre contrato frontend de lectura/envío/restauración. |

## Test Plan
- [x] `python3 -m py_compile backend/routers/tecnica.py backend/routers/guardar_borrador.py backend/init_db.py backend/tests/test_tecnica.py tests/test_tecnica_equipo_solicitado_frontend.py`
- [x] `git diff --check`
- [ ] `pytest tests/test_tecnica_equipo_solicitado_frontend.py backend/tests/test_tecnica.py -q` no se pudo ejecutar localmente: `pytest` no está instalado en este entorno.

## Contributor Checklist
- [x] Linked issue: `Closes #69`
- [ ] Linked an approved issue: #69 lacks `status:approved`
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Ran shellcheck on modified scripts: no shell scripts modified
- [x] Skills tested in at least one agent: not applicable
- [x] Docs updated if behavior changed: migration README updated
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers