### PR TITLE
fix(security): endurecer escape html compartido

### DIFF
--- a/front/Admin-view/admin-regiones.html
+++ b/front/Admin-view/admin-regiones.html
@@ -30,6 +30,7 @@
 <link href="../assets/css/theme.css" rel="stylesheet"/>
 <script src="../assets/js/theme-toggle.js"></script>
 <script src="../assets/js/delight.js"></script>
+<script src="../assets/js/common.js"></script>
 <script src="../assets/js/session-guard.js"></script>
 <script src="../assets/js/apiClient.js"></script>
 <script src="../assets/js/confirmation-modal.js?v=2"></script>
@@ -777,9 +778,6 @@
   });
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
-  function _esc(str) {
-    return String(str || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-  }
   function _show(el, msg) { el.textContent = msg; el.classList.remove('hidden'); }
   function _hide(el)      { el.textContent = ''; el.classList.add('hidden'); }
   function _showEl(id, msg) { const el = document.getElementById(id); if (msg !== undefined) el.textContent = msg; el.classList.remove('hidden'); }

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -36,6 +36,7 @@
     <link href="../assets/css/theme.css" rel="stylesheet"/>
     <script src="../assets/js/theme-toggle.js"></script>
     <script src="../assets/js/delight.js"></script>
+    <script src="../assets/js/common.js"></script>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/apiClient.js"></script>
     <script src="../assets/js/confirmation-modal.js?v=2"></script>
@@ -1154,13 +1155,6 @@
         });
 
       // ── Helpers ─────────────────────────────────────────────────────────────────
-      function _esc(str) {
-        return String(str || "")
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;");
-      }
-
       function _rolBadge(rol) {
         // Fixed category scale (system tokens only): roles stay distinguishable
         // but share one component and harmonized visual weight.

--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -27,6 +27,7 @@
   }
 </script>
 <link href="../assets/css/theme.css" rel="stylesheet"/>
+<script src="../assets/js/common.js"></script>
 <script src="../assets/js/session-guard.js"></script>
 <script src="../assets/js/apiClient.js"></script>
 <script src="../assets/js/confirmation-modal.js?v=2"></script>
@@ -591,9 +592,7 @@
 
         const count = lookup[dateStr] || 0;
         const tooltip = `${dateStr}: ${count} captura${count !== 1 ? 's' : ''}`;
-        svg += `<rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="3" fill="${_heatColor(count)}"
-          onmouseenter="showHeatmapTooltip(event,'${_esc(tooltip)}')"
-          onmouseleave="hideHeatmapTooltip()" style="cursor:pointer"/>`;
+        svg += `<rect class="heatmap-day" data-tooltip="${_esc(tooltip)}" x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="3" fill="${_heatColor(count)}" style="cursor:pointer"/>`;
       }
 
       // Day labels (Mon, Wed, Fri)
@@ -617,6 +616,7 @@
         </div>
       `;
       container.innerHTML = svg + legendHtml;
+      bindHeatmapTooltips(container);
     } catch (_) {
       loading.textContent = 'No se pudo cargar la actividad.';
       loading.classList.remove('hidden');
@@ -634,15 +634,6 @@
     }
     el.textContent = parts.join('  ·  ');
     el.classList.remove('hidden');
-  }
-
-  function _formatDate(iso) {
-    try {
-      const d = new Date(iso);
-      const meses = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
-      // UTC getters: keep the displayed date consistent with the UTC-bucketed heatmap
-      return `${String(d.getUTCDate()).padStart(2,'0')} ${meses[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
-    } catch (_) { return iso; }
   }
 
   function _heatColor(count) {
@@ -672,6 +663,13 @@
   function hideHeatmapTooltip() {
     const tip = document.getElementById('heatmap-tip');
     if (tip) tip.style.display = 'none';
+  }
+
+  function bindHeatmapTooltips(container) {
+    container.querySelectorAll('.heatmap-day').forEach((cell) => {
+      cell.addEventListener('mouseenter', (event) => showHeatmapTooltip(event, cell.dataset.tooltip || ''));
+      cell.addEventListener('mouseleave', hideHeatmapTooltip);
+    });
   }
 
   // ── Edit Profile Modal ─────────────────────────────────────────────────────
@@ -733,20 +731,6 @@
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
-  function _getSession() {
-    try { return JSON.parse(localStorage.getItem('session') || 'null'); }
-    catch (_) { return null; }
-  }
-
-  function _formatRol(rol) {
-    const map = { admin: 'Administrador', capturista: 'Capturista', tecnico: 'Técnico', organizacion: 'Organización' };
-    return map[rol] || rol || '—';
-  }
-
-  function _esc(str) {
-    return String(str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
   function _showError(msg) {
     const banner = document.getElementById('error-banner');
     const text   = document.getElementById('error-text');
@@ -764,23 +748,6 @@
     el.classList.add('hidden');
   }
 
-  // Clear in-progress draft state (the multi-step registration). Does NOT
-  // touch the session — used when starting a fresh capture.
-  function _clearDraftStorage() {
-    localStorage.removeItem('draft_socioeconomico');
-    localStorage.removeItem('draft_tecnica');
-    localStorage.removeItem('draft_gestion');
-    localStorage.removeItem('estudio_id');
-    localStorage.removeItem('beneficiario_id');
-    localStorage.removeItem('solicitud_id');
-  }
-
-  function _clearAllStorage() {
-    localStorage.removeItem('session');
-    localStorage.removeItem('region_ctx');
-    localStorage.removeItem('guest_ctx');
-    _clearDraftStorage();
-  }
 </script>
 </body>
 </html>

--- a/front/Capturista-view/seleccion-region.html
+++ b/front/Capturista-view/seleccion-region.html
@@ -28,6 +28,7 @@
 </script>
 <link href="../assets/css/theme.css" rel="stylesheet"/>
 <script src="../assets/js/theme-toggle.js"></script>
+<script src="../assets/js/common.js"></script>
 <script src="../assets/js/session-guard.js"></script>
 <script src="../assets/js/apiClient.js"></script>
 <link href="../assets/css/seleccion-region.css" rel="stylesheet"/>
@@ -324,18 +325,8 @@
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
-  function _getSession() {
-    try { return JSON.parse(localStorage.getItem('session') || 'null'); }
-    catch (_) { return null; }
-  }
-
   function _authFetch(path, opts) {
     return ApiClient.fetch(path, opts);
-  }
-
-  function _formatRol(rol) {
-    const map = { admin: 'Administrador', capturista: 'Capturista', tecnico: 'Técnico', organizacion: 'Organización' };
-    return map[rol] || rol || '—';
   }
 
   function _showError(msg) {

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -35,6 +35,7 @@
     <link href="../assets/css/theme.css" rel="stylesheet"/>
     <script src="../assets/js/theme-toggle.js"></script>
 <script src="../assets/js/delight.js"></script>
+    <script src="../assets/js/common.js"></script>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/apiClient.js"></script>
     <script src="../assets/js/confirmation-modal.js?v=2"></script>
@@ -515,43 +516,10 @@
       // HELPERS
       // ═══════════════════════════════════════════════════════════════════════════
 
-      function _getSession() {
-        try {
-          return JSON.parse(localStorage.getItem("session") || "null");
-        } catch (_) {
-          return null;
-        }
-      }
-
       // Delegates to ApiClient: paths omit "/api" (added centrally), and the
       // base URL + Bearer auth live in assets/js/apiClient.js.
       function _authFetch(path, opts) {
         return ApiClient.fetch(path, opts);
-      }
-
-      function _formatRol(rol) {
-        const map = {
-          admin: "Administrador",
-          capturista: "Capturista",
-          tecnico: "Técnico",
-        };
-        return map[rol] || rol || "—";
-      }
-
-      function _formatDate(iso) {
-        if (!iso) return "—";
-        try {
-          const d = new Date(iso);
-          return d.toLocaleDateString("es-MX", {
-            year: "numeric",
-            month: "short",
-            day: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          });
-        } catch (_) {
-          return iso;
-        }
       }
 
       function _debounce(fn, ms) {
@@ -560,13 +528,6 @@
           clearTimeout(timer);
           timer = setTimeout(() => fn.apply(this, args), ms);
         };
-      }
-
-      function _escapeHtml(str) {
-        if (str == null) return "";
-        const d = document.createElement("div");
-        d.textContent = str;
-        return d.innerHTML;
       }
 
       function _valOrNa(val) {

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -29,6 +29,7 @@
       };
     </script>
     <link href="assets/css/theme.css" rel="stylesheet"/>
+    <script src="assets/js/common.js"></script>
     <script src="assets/js/session-guard.js"></script>
     <script src="assets/js/apiClient.js"></script>
     <script src="assets/js/confirmation-modal.js?v=2"></script>
@@ -473,28 +474,13 @@
       // ═══════════════════════════════════════════════════════════════════════════
       // HELPERS
       // ═══════════════════════════════════════════════════════════════════════════
-      function _getSession() {
-        try { return JSON.parse(localStorage.getItem("session") || "null"); } catch (_) { return null; }
-      }
       // Thin wrapper over ApiClient: centralizes base URL + Bearer auth +
       // no-store GET caching (see assets/js/apiClient.js). Paths omit "/api".
       function _authFetch(path, opts) {
         return ApiClient.fetch(path, opts);
       }
-      function _escapeHtml(str) {
-        if (str == null) return "";
-        const d = document.createElement("div"); d.textContent = str; return d.innerHTML;
-      }
       function _valOrNaHtml(val) {
         return val != null && val !== "" ? _escapeHtml(String(val)) : '<span class="text-slate-300 italic">No capturado</span>';
-      }
-      function _formatDate(iso) {
-        if (!iso) return "—";
-        try {
-          const d = new Date(iso);
-          if (isNaN(d.getTime())) return iso;
-          return d.toLocaleDateString("es-MX", { year: "numeric", month: "short", day: "numeric", timeZone: "UTC" });
-        } catch (_) { return iso; }
       }
       function _debounce(fn, ms) {
         let timer;

--- a/front/assets/js/common.js
+++ b/front/assets/js/common.js
@@ -1,0 +1,70 @@
+// Shared frontend helpers. Keep these context-safe: _esc is used in both text
+// nodes and HTML attributes built with innerHTML.
+(function () {
+  function _esc(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function _getSession() {
+    try {
+      return JSON.parse(localStorage.getItem("session") || "null");
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function _formatRol(rol) {
+    const map = {
+      admin: "Administrador",
+      capturista: "Capturista",
+      tecnico: "Técnico",
+      organizacion: "Organización",
+    };
+    return map[rol] || rol || "—";
+  }
+
+  function _formatDate(iso) {
+    if (!iso) return "—";
+    try {
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return iso;
+      return d.toLocaleDateString("es-MX", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+      });
+    } catch (_) {
+      return iso;
+    }
+  }
+
+  function _clearDraftStorage() {
+    localStorage.removeItem("draft_socioeconomico");
+    localStorage.removeItem("draft_tecnica");
+    localStorage.removeItem("draft_gestion");
+    localStorage.removeItem("estudio_id");
+    localStorage.removeItem("beneficiario_id");
+    localStorage.removeItem("solicitud_id");
+  }
+
+  function _clearAllStorage() {
+    localStorage.removeItem("session");
+    localStorage.removeItem("region_ctx");
+    localStorage.removeItem("guest_ctx");
+    _clearDraftStorage();
+  }
+
+  window._esc = _esc;
+  window._escapeHtml = _esc;
+  window._getSession = _getSession;
+  window._formatRol = _formatRol;
+  window._formatDate = _formatDate;
+  window._clearDraftStorage = _clearDraftStorage;
+  window._clearAllStorage = _clearAllStorage;
+})();

--- a/front/login.html
+++ b/front/login.html
@@ -27,6 +27,7 @@
   }
 </script>
 <link href="assets/css/theme.css" rel="stylesheet"/>
+<script src="assets/js/common.js"></script>
 <script src="assets/js/apiClient.js"></script>
 <script src="assets/js/theme-toggle.js"></script>
 <link href="assets/css/login.css" rel="stylesheet"/>
@@ -313,11 +314,6 @@
   });
 
   // ── Helpers ──────────────────────────────────────────────────────────────
-
-  function _getSession() {
-    try { return JSON.parse(localStorage.getItem('session') || 'null'); }
-    catch (_) { return null; }
-  }
 
   function _redirectByRole(rol) {
     if (rol === 'admin') {

--- a/front/perfil-organizacion.html
+++ b/front/perfil-organizacion.html
@@ -27,6 +27,7 @@
   }
 </script>
 <link href="assets/css/theme.css" rel="stylesheet"/>
+<script src="assets/js/common.js"></script>
 <script src="assets/js/session-guard.js"></script>
 <script src="assets/js/apiClient.js"></script>
 <script src="assets/js/confirmation-modal.js?v=2"></script>
@@ -537,6 +538,7 @@
       loading.classList.add('hidden');
       container.classList.remove('hidden');
       container.innerHTML = _renderHeatmapSVG(data);
+      bindOrgHeatmapTooltips(container);
     } catch (_) {
       loading.textContent = 'No se pudo cargar la actividad.';
     }
@@ -571,8 +573,7 @@
       const count = days[i].count;
       const color = count === 0 ? heatColors[0] : count <= 2 ? heatColors[1] : count <= 5 ? heatColors[2] : count <= 9 ? heatColors[3] : heatColors[4];
       const tip = `${days[i].dateStr}: ${count} captura${count !== 1 ? 's' : ''}`;
-      svg += `<rect x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" fill="${color}"
-        onmouseenter="showTip(event,'${_esc(tip)}')" onmouseleave="hideTip()" style="cursor:pointer"/>`;
+      svg += `<rect class="heatmap-day" data-tooltip="${_esc(tip)}" x="${x}" y="${y}" width="${cellSize}" height="${cellSize}" rx="2" fill="${color}" style="cursor:pointer"/>`;
     }
     svg += '</svg>';
     const legend = '<div class="flex items-center gap-2 mt-4 text-xs text-slate-400 justify-end"><span>Menos</span>' +
@@ -586,6 +587,13 @@
     tip.textContent = text; tip.style.left = ev.pageX + 'px'; tip.style.top = ev.pageY + 'px'; tip.style.display = 'block';
   }
   function hideTip() { const tip = document.getElementById('htip'); if (tip) tip.style.display = 'none'; }
+
+  function bindOrgHeatmapTooltips(container) {
+    container.querySelectorAll('.heatmap-day').forEach((cell) => {
+      cell.addEventListener('mouseenter', (event) => showTip(event, cell.dataset.tooltip || ''));
+      cell.addEventListener('mouseleave', hideTip);
+    });
+  }
 
   // ── Beneficiarios de la organización ────────────────────────────────────────
   async function loadOrgBeneficiarios(orgId) {
@@ -672,15 +680,6 @@
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
-  function _getSession() {
-    try { return JSON.parse(localStorage.getItem('session') || 'null'); }
-    catch (_) { return null; }
-  }
-
-  function _esc(str) {
-    return String(str || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  }
-
   function _initial(nombre) {
     const s = String(nombre || '').trim();
     if (!s) return '?';
@@ -707,23 +706,6 @@
     banner.classList.remove('hidden');
   }
 
-  // Clear in-progress draft state (the multi-step registration). Does NOT
-  // touch the session — used when starting a fresh guest capture.
-  function _clearDraftStorage() {
-    localStorage.removeItem('draft_socioeconomico');
-    localStorage.removeItem('draft_tecnica');
-    localStorage.removeItem('draft_gestion');
-    localStorage.removeItem('estudio_id');
-    localStorage.removeItem('beneficiario_id');
-    localStorage.removeItem('solicitud_id');
-  }
-
-  function _clearAllStorage() {
-    localStorage.removeItem('session');
-    localStorage.removeItem('region_ctx');
-    localStorage.removeItem('guest_ctx');
-    _clearDraftStorage();
-  }
 </script>
 </body>
 </html>

--- a/tests/test_common_frontend_security.py
+++ b/tests/test_common_frontend_security.py
@@ -1,0 +1,50 @@
+"""Contract tests for shared frontend HTML escaping."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONT = ROOT / "front"
+COMMON_JS = FRONT / "assets" / "js" / "common.js"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_common_escape_covers_attribute_delimiters() -> None:
+    js = _read(COMMON_JS)
+
+    assert "function _esc(value)" in js
+    assert '.replace(/&/g, "&amp;")' in js
+    assert '.replace(/</g, "&lt;")' in js
+    assert '.replace(/>/g, "&gt;")' in js
+    assert '.replace(/"/g, "&quot;")' in js
+    assert '.replace(/\'/g, "&#039;")' in js
+    assert "window._escapeHtml = _esc;" in js
+
+
+def test_common_helpers_loaded_on_escape_consumers() -> None:
+    expected_scripts = {
+        FRONT / "login.html": 'src="assets/js/common.js"',
+        FRONT / "perfil-organizacion.html": 'src="assets/js/common.js"',
+        FRONT / "admin-beneficiarios.html": 'src="assets/js/common.js"',
+        FRONT / "Capturista-view" / "perfil-capturista.html": 'src="../assets/js/common.js"',
+        FRONT / "Capturista-view" / "seleccion-region.html": 'src="../assets/js/common.js"',
+        FRONT / "Admin-view" / "admin-usuarios.html": 'src="../assets/js/common.js"',
+        FRONT / "Admin-view" / "admin-regiones.html": 'src="../assets/js/common.js"',
+        FRONT / "Tecnico-view" / "vista_tecnicos.html": 'src="../assets/js/common.js"',
+    }
+
+    for path, script in expected_scripts.items():
+        assert script in _read(path), path
+
+
+def test_no_local_escape_helpers_or_inline_heatmap_handlers_remain() -> None:
+    html = "\n".join(path.read_text(encoding="utf-8") for path in FRONT.rglob("*.html"))
+
+    assert "function _esc" not in html
+    assert "function _escapeHtml" not in html
+    assert "onmouseenter=" not in html
+    assert "onmouseleave=" not in html
+    assert 'data-tooltip="${_esc(' in html


### PR DESCRIPTION
## Linked Issue
Closes #42

Note: issue #42 is linked, but it currently does not have the `status:approved` label. If PR validation requires that label, this PR will need the issue to be approved before merge.

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Agrega `front/assets/js/common.js` con `_esc` completo para texto y atributos HTML.
- Centraliza helpers duplicados y carga `common.js` en las vistas que consumen escape/session/formato.
- Reemplaza tooltips inline del heatmap por `addEventListener` para evitar inyección por atributos.

## Changes
| File | Change |
|------|--------|
| `front/assets/js/common.js` | Nuevo helper compartido: `_esc`, `_escapeHtml`, `_getSession`, `_formatRol`, `_formatDate`, `_clearDraftStorage`, `_clearAllStorage`. |
| `front/Capturista-view/perfil-capturista.html` | Usa `common.js`, elimina helpers locales y cambia heatmap a listeners. |
| `front/perfil-organizacion.html` | Usa `common.js`, elimina helpers locales y cambia heatmap a listeners. |
| `front/login.html`, `front/Capturista-view/seleccion-region.html` | Usan `common.js` y eliminan helpers duplicados. |
| `front/admin-beneficiarios.html`, `front/Admin-view/admin-usuarios.html`, `front/Admin-view/admin-regiones.html`, `front/Tecnico-view/vista_tecnicos.html` | Usan el escape común y eliminan copias locales. |
| `tests/test_common_frontend_security.py` | Agrega contratos para escape de comillas, carga del helper y ausencia de handlers inline. |

## Test Plan
- [x] `node --check front/assets/js/common.js`
- [x] `python3 -m py_compile tests/test_common_frontend_security.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest tests/test_common_frontend_security.py -q` no se pudo ejecutar localmente: `pytest` no está instalado en este entorno.

## Contributor Checklist
- [x] Linked issue: `Closes #42`
- [ ] Linked an approved issue: #42 lacks `status:approved`
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Ran shellcheck on modified scripts: no shell scripts modified
- [x] Skills tested in at least one agent: not applicable
- [x] Docs updated if behavior changed: not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers