### PR TITLE
fix(tecnica): restaurar selector de unidades

### DIFF
--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -863,6 +863,17 @@
       let uploadedPhotoUrl = null;        // canonical storage:// reference (DB)
       let uploadedPhotoPreviewUrl = null; // browser-renderable URL (preview only)
 
+      function toMeasurementSystem(unit) {
+        if (unit === "metric" || unit === "cm") return "metric";
+        if (unit === "imperial" || unit === "in") return "imperial";
+        return null;
+      }
+
+      function restoreMeasurementSystem(data, setVal) {
+        const system = toMeasurementSystem(data?.unidad_captura || data?.unidad_medida);
+        if (system) setVal("unidad_medida", system);
+      }
+
       // Auth guard + Draft Resume
       (async function () {
         // Role guard: capturista may access this form.
@@ -938,9 +949,7 @@
                 }
               }
 
-              // Derive system from stored capture unit — sets the UI selector.
-              const system = (data.unidad_captura === "cm") ? "metric" : "imperial";
-              setVal("unidad_medida", system);
+              restoreMeasurementSystem(data, setVal);
 
               // Set numeric fields verbatim (no arithmetic — values are stored
               // in capture units for borradores and in canonical units for completos,
@@ -1010,10 +1019,7 @@
               const chk = document.querySelector('[name="tiene_observaciones"]');
               if (chk) { chk.checked = true; chk.dispatchEvent(new Event("change")); }
             }
-            if (data.unidad_medida) {
-              const system = data.unidad_medida === "cm" ? "metric" : "imperial";
-              setVal("unidad_medida", system);
-            }
+            restoreMeasurementSystem(data, setVal);
             setVal("altura_total_in", data.altura_total_in);
             setVal("peso_kg", data.peso_kg);
             setVal("medida_cabeza_asiento", data.medida_cabeza_asiento);

--- a/tests/test_tecnica_unit_selector_frontend.py
+++ b/tests/test_tecnica_unit_selector_frontend.py
@@ -1,0 +1,28 @@
+"""Contract tests for tecnica.html unit selector restore."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TECNICA_FILE = ROOT / "front" / "Capturista-view" / "tecnica.html"
+
+
+def _read_tecnica_html() -> str:
+    return TECNICA_FILE.read_text(encoding="utf-8")
+
+
+def test_declares_unit_to_selector_mapping() -> None:
+    html = _read_tecnica_html()
+
+    assert "function toMeasurementSystem(unit)" in html
+    assert 'unit === "metric" || unit === "cm"' in html
+    assert 'unit === "imperial" || unit === "in"' in html
+
+
+def test_restores_selector_from_backend_or_local_draft_unit_field() -> None:
+    html = _read_tecnica_html()
+
+    assert "function restoreMeasurementSystem(data, setVal)" in html
+    assert "data?.unidad_captura || data?.unidad_medida" in html
+    assert 'setVal("unidad_medida", system)' in html
+    assert html.count("restoreMeasurementSystem(data, setVal);") >= 2


### PR DESCRIPTION
## Linked Issue
Closes #104

Note: issue #104 is linked, but it currently does not have the `status:approved` label. If PR validation requires that label, this PR will need the issue to be approved before merge.

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Unifica la restauración del selector de unidades del formulario técnico.
- Mapea correctamente `in -> imperial` y `cm -> metric`, tolerando también valores UI legacy `imperial`/`metric`.
- Cubre tanto borradores cargados desde backend como borradores locales.

## Changes
| File | Change |
|------|--------|
| `front/Capturista-view/tecnica.html` | Agrega `toMeasurementSystem` y `restoreMeasurementSystem`, reutilizados en ambos caminos de restauración. |
| `tests/test_tecnica_unit_selector_frontend.py` | Agrega contratos para el mapeo de unidades y restauración por `unidad_captura`/`unidad_medida`. |

## Test Plan
- [x] `python3 -m py_compile tests/test_tecnica_unit_selector_frontend.py`
- [x] `git diff --check`
- [x] `python3 -m pytest tests/test_tecnica_unit_selector_frontend.py -q` (`2 passed`)

## Contributor Checklist
- [x] Linked issue: `Closes #104`
- [ ] Linked an approved issue: #104 lacks `status:approved`
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Ran shellcheck on modified scripts: no shell scripts modified
- [x] Skills tested in at least one agent: not applicable
- [x] Docs updated if behavior changed: not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers