### PR TITLE
feat(tecnica): persist equipo_solicitado + estudio clinico; drop dead DB columns

### DIFF
--- a/backend/migrations/0022_add_equipo_solicitado_estudio_clinico.sql
+++ b/backend/migrations/0022_add_equipo_solicitado_estudio_clinico.sql
@@ -1,0 +1,12 @@
+-- 0022: Persist two fields the UI already collects but never stored.
+--   * equipo_solicitado: requested equipment type (select in tecnica form).
+--   * estudio_clinico_path/url: clinical study document uploaded from the
+--     tecnica form (mirrors foto_path/foto_url; stored in the
+--     documentos-estudio bucket).
+-- Applied to Supabase on 2026-07-01 via MCP migration
+-- add_equipo_solicitado_estudio_clinico.
+
+ALTER TABLE public.solicitudes_tecnicas
+    ADD COLUMN IF NOT EXISTS equipo_solicitado text,
+    ADD COLUMN IF NOT EXISTS estudio_clinico_path text,
+    ADD COLUMN IF NOT EXISTS estudio_clinico_url text;

--- a/backend/migrations/0023_drop_dead_columns.sql
+++ b/backend/migrations/0023_drop_dead_columns.sql
@@ -1,0 +1,28 @@
+-- 0023: Drop dead columns confirmed by the 2026-07-01 code + DB audit.
+-- All had 0 non-null rows and no runtime writer:
+--   * beneficiarios.folio: legacy identifier, superseded by curp_benef
+--     (Issue #32); read-only fallback in code, removed alongside this drop.
+--   * solicitudes_tecnicas.estado_silla / lugar_entrega / fecha_entrega:
+--     unshipped delivery-tracking design, never wired.
+--   * solicitudes_tecnicas.requiere_soporte_oxigeno: superseded by
+--     soporte_oxigeno (migration 0018).
+--   * tutores.antiguedad: superseded by antiguedad_meses.
+--   * estudios_socioeconomicos.otras_fuentes_ingreso / monto_otras_fuentes:
+--     these live on tutores, the estudios copies were never written.
+-- Applied to Supabase on 2026-07-01 via MCP migration drop_dead_columns.
+
+ALTER TABLE public.beneficiarios
+    DROP COLUMN IF EXISTS folio;
+
+ALTER TABLE public.solicitudes_tecnicas
+    DROP COLUMN IF EXISTS estado_silla,
+    DROP COLUMN IF EXISTS lugar_entrega,
+    DROP COLUMN IF EXISTS fecha_entrega,
+    DROP COLUMN IF EXISTS requiere_soporte_oxigeno;
+
+ALTER TABLE public.tutores
+    DROP COLUMN IF EXISTS antiguedad;
+
+ALTER TABLE public.estudios_socioeconomicos
+    DROP COLUMN IF EXISTS otras_fuentes_ingreso,
+    DROP COLUMN IF EXISTS monto_otras_fuentes;

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -442,7 +442,6 @@ def listar_beneficiarios_admin(
             b.id AS beneficiario_id,
             b.nombre,
             b.curp_benef,
-            b.folio,
             b.telefonos,
             b.ciudad,
             COALESCE(p.nombre, '') AS pais_nombre,
@@ -511,7 +510,6 @@ def exportar_beneficiarios_admin(
         SELECT
             b.id AS beneficiario_id,
             b.curp_benef,
-            b.folio,
             b.nombre,
             b.email,
             b.calle,
@@ -588,7 +586,7 @@ def exportar_beneficiarios_admin(
         edad = _calcular_edad(row.get("fecha_nacimiento"))
 
         ws.append([
-            row.get("curp_benef") or row.get("folio") or row.get("beneficiario_id"),
+            row.get("curp_benef") or row.get("beneficiario_id"),
             row.get("nombre") or "",
             row.get("email") or "Sin correo",
             direccion,

--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -130,6 +130,9 @@ class GuardarBorradorRequest(BaseModel):
     medida_ancho_cadera: Optional[str] = None
     foto_path: Optional[str] = None
     foto_url: Optional[str] = None
+    equipo_solicitado: Optional[str] = None
+    estudio_clinico_path: Optional[str] = None
+    estudio_clinico_url: Optional[str] = None
     entidad_solicitante: Optional[str] = None
     prioridad: Optional[str] = None
     justificacion: Optional[str] = None
@@ -662,9 +665,11 @@ def _create_borrador(
                  altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura,
-                 unidad_peso_captura, foto_url, entidad_solicitante, prioridad,
+                 unidad_peso_captura, foto_url, equipo_solicitado,
+                 estudio_clinico_path, estudio_clinico_url,
+                 entidad_solicitante, prioridad,
                  justificacion, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -686,6 +691,9 @@ def _create_borrador(
                 body.unidad_medida,
                 body.unidad_peso_captura,
                 body.foto_url,
+                body.equipo_solicitado,
+                body.estudio_clinico_path,
+                body.estudio_clinico_url,
                 body.entidad_solicitante,
                 body.prioridad,
                 body.justificacion,
@@ -901,6 +909,9 @@ def _patch_solicitud(db: _DBAdapter, body: GuardarBorradorRequest, solicitud_id:
         ("control_de_piernas", body.control_de_piernas),
         ("padecimiento", body.padecimiento),
         ("soporte_oxigeno", body.soporte_oxigeno),
+        ("equipo_solicitado", body.equipo_solicitado),
+        ("estudio_clinico_path", body.estudio_clinico_path),
+        ("estudio_clinico_url", body.estudio_clinico_url),
         ("entidad_solicitante", body.entidad_solicitante),
         ("prioridad", body.prioridad),
         ("justificacion", body.justificacion),

--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -428,7 +428,6 @@ class GuardarBorradorResponse(BaseModel):
     solicitud_id: int
     beneficiario_id: int
     curp: Optional[str] = None
-    folio: Optional[str] = None
     status: str
 
 
@@ -529,7 +528,7 @@ def guardar_borrador(
     Atomic draft save: create or update all 3 forms in one transaction.
 
     CREATE mode (no estudio_id):
-      - Generates folio, inserts beneficiario + estudio + solicitud atomically.
+      - Inserts beneficiario + estudio + solicitud atomically; CURP is the natural identifier.
 
     UPDATE mode (has estudio_id):
       - Updates existing beneficiario + estudio + solicitud atomically.
@@ -549,9 +548,6 @@ def _create_borrador(
     if body.region_id is None:
         raise HTTPException(status_code=422, detail="region_id es obligatorio para crear un borrador")
 
-    # Folio is no longer generated — CURP is the natural identifier (Issue #32).
-    folio = None
-
     nombre_composed = _compose_nombre(body) or None
 
     # Reject a draft whose CURP already belongs to another beneficiario.
@@ -559,15 +555,15 @@ def _create_borrador(
         _assert_curp_disponible(db, body.curp)
 
     try:
-        # 1. INSERT beneficiario (folio NULL — curp_benef is the identifier)
+        # 1. INSERT beneficiario (curp_benef is the natural identifier, Issue #32)
         beneficiario_id = db.execute(
             """
             INSERT INTO beneficiarios
                 (nombre, nombres, apellido_paterno, apellido_materno, curp_benef,
                  fecha_nacimiento, diagnostico, calle, num_ext, num_int, colonia, ciudad,
                  estado_codigo, estado_nombre, sexo, telefonos, email,
-                 folio, region_id, sede)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                 region_id, sede)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -588,7 +584,6 @@ def _create_borrador(
                 body.sexo,
                 body.telefonos,
                 body.email,
-                folio,
                 body.region_id,
                 body.sede,
             ),
@@ -712,7 +707,6 @@ def _create_borrador(
         solicitud_id=solicitud_id,
         beneficiario_id=beneficiario_id,
         curp=body.curp,
-        folio=folio,
         status=body.status or "borrador",
     )
 
@@ -789,19 +783,17 @@ def _update_borrador(
         logger.exception("guardar-borrador UPDATE failed: %s", exc)
         raise HTTPException(status_code=500, detail="Error interno al actualizar el borrador") from exc
 
-    # Fetch current CURP / folio for the response
+    # Fetch current CURP for the response
     ben_row = db.execute(
-        "SELECT curp_benef, folio FROM beneficiarios WHERE id = %s", (beneficiario_id,)
+        "SELECT curp_benef FROM beneficiarios WHERE id = %s", (beneficiario_id,)
     ).fetchone()
     curp = ben_row["curp_benef"] if ben_row else None
-    folio = ben_row["folio"] if ben_row else None
 
     return GuardarBorradorResponse(
         estudio_id=body.estudio_id,
         solicitud_id=solicitud_id or 0,
         beneficiario_id=beneficiario_id,
         curp=curp,
-        folio=folio,
         status="borrador",
     )
 

--- a/backend/routers/perfiles.py
+++ b/backend/routers/perfiles.py
@@ -327,7 +327,7 @@ def get_my_heatmap(
 
 @router.get("/me/beneficiarios")
 def get_my_beneficiarios(
-    q: Annotated[str | None, Query(description="Search beneficiary name or folio")] = None,
+    q: Annotated[str | None, Query(description="Search beneficiary name or CURP")] = None,
     status: Annotated[str | None, Query(description="Filter by status: borrador or completo")] = None,
     db: Annotated[_DBAdapter, Depends(get_db)] = None,
     user: Annotated[CurrentUser, Depends(require_roles("capturista", "organizacion", "admin"))] = None,
@@ -335,7 +335,7 @@ def get_my_beneficiarios(
     """Return beneficiary list with edit links for the current user.
 
     Args:
-        q: Optional search string to filter by beneficiary name or folio.
+        q: Optional search string to filter by beneficiary name or CURP.
         status: Optional status filter ('borrador' or 'completo').
     """
     conditions = ["e.usuario_id = %s"]
@@ -346,9 +346,9 @@ def get_my_beneficiarios(
         params.append(status)
 
     if q is not None:
-        conditions.append("(b.nombre ILIKE %s OR b.curp_benef ILIKE %s OR b.folio ILIKE %s)")
+        conditions.append("(b.nombre ILIKE %s OR b.curp_benef ILIKE %s)")
         search_pattern = f"%{q}%"
-        params.extend([search_pattern, search_pattern, search_pattern])
+        params.extend([search_pattern, search_pattern])
 
     where_clause = " AND ".join(conditions)
 
@@ -392,7 +392,6 @@ def get_my_beneficiarios(
             b.telefonos,
             b.email,
             b.curp_benef,
-            b.folio,
             b.region_id,
             b.created_at              AS beneficiario_created_at
         FROM estudios_socioeconomicos e
@@ -444,7 +443,6 @@ def get_my_beneficiarios(
             "email": r["email"],
             "sexo": r["sexo"],
             "curp_benef": r["curp_benef"],
-            "folio": r["folio"],
             "region_id": r["region_id"],
         }
         estudio["tutores"] = tutors_by_beneficiario.get(r["beneficiario_id"], [])
@@ -888,8 +886,7 @@ def get_org_beneficiarios(
             e.status,
             e.created_at,
             COALESCE(e.elaboro_estudio, u.nombre) AS elaboro_estudio,
-            b.nombre AS beneficiario_nombre,
-            b.folio
+            b.nombre AS beneficiario_nombre
         FROM estudios_socioeconomicos e
         JOIN beneficiarios b ON b.id = e.beneficiario_id
         LEFT JOIN usuarios u ON u.id = e.usuario_id
@@ -903,7 +900,6 @@ def get_org_beneficiarios(
         {
             "estudio_id": r["estudio_id"],
             "beneficiario_nombre": r["beneficiario_nombre"],
-            "folio": r["folio"],
             "status": r["status"],
             "elaboro_estudio": r["elaboro_estudio"],
             "fecha": r["created_at"].isoformat() if r["created_at"] else None,

--- a/backend/routers/socioeconomico.py
+++ b/backend/routers/socioeconomico.py
@@ -5,8 +5,7 @@ Changes from v1:
 - Uses Depends(get_db) instead of context manager
 - Uses require_auth (JWT) — identity via usuario.usuario_id (v2)
 - region_id + sede at top level of EstudioCreateRequest (moved from EstudioIn)
-- Calls generate_folio() to assign structured folio to each beneficiario
-- Returns folio in EstudioCreateResponse
+- CURP (curp_benef) is the natural beneficiary identifier (folio column dropped, Issue #32)
 """
 
 import os
@@ -541,9 +540,8 @@ class EstudioCreateRequest(BaseModel):
 class EstudioCreateResponse(BaseModel):
     estudio_id: int
     beneficiario_id: int
-    # CURP is the natural identifier shown to users (replaces folio).
+    # CURP is the natural identifier shown to users (Issue #32: folio column dropped).
     curp: Optional[str] = None
-    folio: Optional[str] = None
     status: str
 
 
@@ -767,7 +765,6 @@ def crear_estudio(
         estudio_id=estudio_id,
         beneficiario_id=beneficiario_id,
         curp=b.curp,
-        folio=None,
         status=estudio.status,
     )
 
@@ -775,7 +772,7 @@ def crear_estudio(
 def _curp_duplicada_error(db: _DBAdapter, curp: str) -> HTTPException:
     """Build a structured 409 describing the beneficiario that already owns CURP."""
     existente = db.execute(
-        "SELECT id, nombre, folio FROM beneficiarios WHERE curp_benef = %s",
+        "SELECT id, nombre FROM beneficiarios WHERE curp_benef = %s",
         (curp,),
     ).fetchone()
     detalle = {
@@ -787,7 +784,6 @@ def _curp_duplicada_error(db: _DBAdapter, curp: str) -> HTTPException:
         detalle["beneficiario_existente"] = {
             "id": existente["id"],
             "nombre": existente.get("nombre"),
-            "folio": existente.get("folio"),
         }
     return HTTPException(status_code=409, detail=detalle)
 
@@ -907,7 +903,6 @@ def mis_capturas(
             b.id         AS beneficiario_id,
             b.nombre     AS beneficiario_nombre,
             b.curp_benef,
-            b.folio,
             b.ciudad     AS beneficiario_ciudad,
             b.telefonos  AS beneficiario_telefonos
         FROM estudios_socioeconomicos e

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -146,12 +146,12 @@ def _build_list_where_clause(
     if q and q.strip():
         term = f"%{q.strip()}%"
         clauses.append(
-            "(b.nombre ILIKE %s OR b.curp_benef ILIKE %s OR b.folio ILIKE %s OR "
+            "(b.nombre ILIKE %s OR b.curp_benef ILIKE %s OR "
             "b.ciudad ILIKE %s OR "
             "r.nombre ILIKE %s OR "
             "p.nombre ILIKE %s)"
         )
-        params.extend([term, term, term, term, term, term])
+        params.extend([term, term, term, term, term])
 
     # ── Sede ──────────────────────────────────────────────────────────────
     if sede and sede.strip():
@@ -794,7 +794,6 @@ def listar_beneficiarios_tecnica(
         SELECT
             b.id AS beneficiario_id,
             b.nombre,
-            b.folio,
             b.telefonos,
             b.ciudad,
             COALESCE(p.nombre, '') AS pais_nombre,
@@ -889,7 +888,7 @@ def exportar_beneficiarios_tecnica(
         f"""
         SELECT
             b.id AS beneficiario_id,
-            b.folio,
+            b.curp_benef,
             b.nombre,
             b.email,
             b.calle,
@@ -969,7 +968,7 @@ def exportar_beneficiarios_tecnica(
         edad = _calcular_edad(row.get("fecha_nacimiento"))
 
         ws.append([
-            row.get("folio") or row.get("beneficiario_id"),
+            row.get("curp_benef") or row.get("beneficiario_id"),
             row.get("nombre") or "",
             row.get("email") or "Sin correo",
             direccion,

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -40,6 +40,10 @@ _BUCKET = "fotos-tecnica"
 _SIGNED_URL_TTL_SECONDS = 60
 _STORAGE_URL_PREFIX = f"storage://{_BUCKET}/"
 
+_DOCUMENT_BUCKET = "documentos-estudio"
+_DOCUMENT_ALLOWED_CONTENT_TYPES = {"image/jpeg", "image/png", "application/pdf"}
+_DOCUMENT_ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".pdf"}
+
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -332,12 +336,12 @@ def _classify_db_error(exc: Exception) -> HTTPException:
     )
 
 
-def _storage():
+def _storage(bucket: str = _BUCKET):
     from supabase import create_client
     return create_client(
         os.environ["SUPABASE_URL"],
         os.environ["SUPABASE_SERVICE_KEY"],
-    ).storage.from_(_BUCKET)
+    ).storage.from_(bucket)
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +368,9 @@ class SolicitudCreateRequest(BaseModel):
     medida_ancho_cadera: Optional[Decimal] = None
     foto_path: Optional[str] = None
     foto_url: Optional[str] = None
+    equipo_solicitado: Optional[str] = None
+    estudio_clinico_path: Optional[str] = None
+    estudio_clinico_url: Optional[str] = None
     entidad_solicitante: Optional[str] = None
     prioridad: Optional[str] = None
     justificacion: Optional[str] = None
@@ -499,6 +506,9 @@ class SolicitudUpdateRequest(BaseModel):
     medida_ancho_cadera: Optional[Decimal] = None
     foto_path: Optional[str] = None
     foto_url: Optional[str] = None
+    equipo_solicitado: Optional[str] = None
+    estudio_clinico_path: Optional[str] = None
+    estudio_clinico_url: Optional[str] = None
     entidad_solicitante: Optional[str] = None
     prioridad: Optional[str] = None
     justificacion: Optional[str] = None
@@ -1081,6 +1091,42 @@ async def upload_foto(
     }
 
 
+@router.post("/upload-estudio-clinico")
+async def upload_estudio_clinico(
+    archivo: UploadFile = File(...),
+    _usuario: Annotated[CurrentUser, Depends(require_roles("capturista", "tecnico", "admin", "organizacion"))] = None,
+) -> dict:
+    """Upload a clinical study document (JPG, PNG, or PDF) to documentos-estudio bucket."""
+    if archivo.content_type not in _DOCUMENT_ALLOWED_CONTENT_TYPES:
+        raise HTTPException(status_code=400, detail="Tipo de archivo no permitido")
+
+    _, ext = os.path.splitext(archivo.filename or "")
+    if ext.lower() not in _DOCUMENT_ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Tipo de archivo no permitido")
+
+    data = await archivo.read()
+    if len(data) > _MAX_SIZE_BYTES:
+        raise HTTPException(status_code=400, detail="El archivo excede 10MB")
+
+    filename = f"estudio_clinico/{uuid.uuid4()}{ext.lower()}"
+
+    try:
+        _storage(_DOCUMENT_BUCKET).upload(
+            path=filename,
+            file=data,
+            file_options={"content-type": archivo.content_type},
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Error al subir el estudio clínico") from exc
+
+    canonical_url = f"storage://{_DOCUMENT_BUCKET}/{filename}"
+    return {
+        "estudio_clinico_path": filename,
+        "estudio_clinico_url": canonical_url,
+        "estudio_clinico_url_resolved": _resolve_storage_url(canonical_url, _DOCUMENT_BUCKET),
+    }
+
+
 @router.post("/solicitudes", status_code=201, response_model=SolicitudCreateResponse)
 def crear_solicitud(
     body: SolicitudCreateRequest,
@@ -1120,8 +1166,9 @@ def crear_solicitud(
                  soporte_oxigeno, altura_total_in, peso_kg,
                  medida_cabeza_asiento, medida_hombro_asiento, medida_prof_asiento,
                  medida_rodilla_talon, medida_ancho_cadera, unidad_captura, unidad_peso_captura, foto_url,
+                 equipo_solicitado, estudio_clinico_path, estudio_clinico_url,
                  entidad_solicitante, prioridad, justificacion, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -1143,6 +1190,9 @@ def crear_solicitud(
                 body.unidad_medida,
                 body.unidad_peso_captura,
                 resolved_foto_url,
+                body.equipo_solicitado,
+                body.estudio_clinico_path,
+                body.estudio_clinico_url,
                 body.entidad_solicitante,
                 body.prioridad,
                 body.justificacion,
@@ -1197,6 +1247,8 @@ def obtener_solicitud(
     # needing a separate fetch — raw storage:// URIs cannot be used as <img src>.
     if out.get("foto_url"):
         out["foto_url_resolved"] = _resolve_storage_url(out["foto_url"], _BUCKET)
+    if out.get("estudio_clinico_url"):
+        out["estudio_clinico_url_resolved"] = _resolve_storage_url(out["estudio_clinico_url"], _DOCUMENT_BUCKET)
     return out
 
 

--- a/backend/tests/test_guardar_borrador.py
+++ b/backend/tests/test_guardar_borrador.py
@@ -98,8 +98,7 @@ class TestCrearBorrador:
         assert data["estudio_id"] > 0
         assert data["solicitud_id"] > 0
         assert data["beneficiario_id"] > 0
-        # Issue #32: folio is no longer generated; CURP is the natural identifier.
-        assert data["folio"] is None
+        # Issue #32: folio column dropped; CURP is the natural identifier.
         assert "curp" in data
         assert data["status"] == "borrador"
 
@@ -124,8 +123,6 @@ class TestCrearBorrador:
         assert res.status_code == 201, f"Expected 201, got {res.status_code}: {res.text}"
         data = res.json()
         assert data["beneficiario_id"] > 0
-        # Issue #32: folio is no longer generated for new drafts.
-        assert data["folio"] is None
 
     def test_create_with_tutor1_data(self, client, capturista_headers, region_lon):
         """CREATE mode: include tutor 1 data → 201."""
@@ -265,8 +262,6 @@ class TestActualizarBorrador:
         assert res.status_code == 201, f"Expected 201, got {res.status_code}: {res.text}"
         data = res.json()
         assert data["estudio_id"] == ids["estudio_id"]
-        # Issue #32: legacy draft created in this test has no folio (not generated).
-        assert "folio" in data
 
     def test_update_adds_tutor(self, client, capturista_headers, region_lon):
         """UPDATE mode: add tutor data to existing borrador."""

--- a/backend/tests/test_perfiles.py
+++ b/backend/tests/test_perfiles.py
@@ -23,7 +23,6 @@ class TestMisCapturas:
         assert len(data) >= 1
         for item in data:
             assert "estudio_id" in item
-            assert "folio" in item
             assert "beneficiario_nombre" in item
             assert "elaboro_estudio" in item
             assert "fecha_estudio" in item
@@ -307,7 +306,6 @@ class TestMeBeneficiarios:
         assert len(data) >= 1
         for item in data:
             assert "estudio_id" in item
-            assert "folio" in item
             assert "beneficiario_nombre" in item
             assert "status" in item
             assert "edit_url" in item
@@ -499,11 +497,11 @@ class TestBeneficiarioSearchFilter:
         assert res.status_code == 200
         data = res.json()
         assert len(data) >= 1
-        # All results should contain "mar" (case-insensitive) in beneficiario_nombre or folio
+        # All results should contain "mar" (case-insensitive) in beneficiario_nombre or curp_benef
         for item in data:
             name_match = "mar" in item["beneficiario_nombre"].lower()
-            folio_match = item["folio"] and "mar" in item["folio"].lower()
-            assert name_match or folio_match, f"No match in {item}"
+            curp_match = item.get("beneficiario", {}).get("curp_benef") and "mar" in item["beneficiario"]["curp_benef"].lower()
+            assert name_match or curp_match, f"No match in {item}"
 
     def test_beneficiarios_search_no_results(self, client, capturista_headers):
         """GET /api/me/beneficiarios?q=ZZZZNOTFOUND returns empty."""
@@ -724,7 +722,7 @@ class TestOrganizacionesCRUD:
         assert res.status_code == 200
         beneficiarios = res.json()
         assert len(beneficiarios) >= 1
-        assert any("folio" in b and "beneficiario_nombre" in b for b in beneficiarios)
+        assert any("beneficiario_nombre" in b for b in beneficiarios)
 
     def test_voluntario_registered_on_org_capture(
         self, client, admin_headers, region_lon

--- a/backend/tests/test_vista_tecnicos_integration.py
+++ b/backend/tests/test_vista_tecnicos_integration.py
@@ -40,7 +40,6 @@ def _create_beneficiario(
     _test_db_conn,
     *,
     nombre: str,
-    folio: str,
     region_id: int | None = None,
     ciudad: str | None = None,
     diagnostico: str | None = None,
@@ -49,10 +48,10 @@ def _create_beneficiario(
     with _test_db_conn.cursor() as cur:
         cur.execute(
             """
-            INSERT INTO beneficiarios (nombre, folio, region_id, ciudad, diagnostico, telefonos)
-            VALUES (%s, %s, %s, %s, %s, %s) RETURNING *
+            INSERT INTO beneficiarios (nombre, region_id, ciudad, diagnostico, telefonos)
+            VALUES (%s, %s, %s, %s, %s) RETURNING *
             """,
-            (nombre, folio, region_id, ciudad, diagnostico, telefonos),
+            (nombre, region_id, ciudad, diagnostico, telefonos),
         )
         row = dict(cur.fetchone())
     _test_db_conn.commit()
@@ -125,10 +124,10 @@ def test_listar_beneficiarios_with_pais_and_region_filters(
     region_b = _create_region(_test_db_conn, pais["id"], "Irapuato", "IRA")
 
     # Ben in region_a
-    b1 = _create_beneficiario(_test_db_conn, nombre="Ana López", folio="MX-LON-001",
+    b1 = _create_beneficiario(_test_db_conn, nombre="Ana López",
                                region_id=region_a["id"], ciudad="León")
     # Ben in region_b
-    b2 = _create_beneficiario(_test_db_conn, nombre="Luis Pérez", folio="MX-IRA-001",
+    b2 = _create_beneficiario(_test_db_conn, nombre="Luis Pérez",
                                region_id=region_b["id"], ciudad="Irapuato")
 
     _create_estudio(_test_db_conn, b1["id"], tecnico_user["id"], "Sede León")
@@ -178,9 +177,9 @@ def test_peso_range_filter(client, _test_db_conn, tecnico_user, tecnico_headers)
     pais = _create_pais(_test_db_conn, "MX", "MX")
     region = _create_region(_test_db_conn, pais["id"], "Centro", "CEN")
 
-    b1 = _create_beneficiario(_test_db_conn, nombre="Peso60", folio="MX-001",
+    b1 = _create_beneficiario(_test_db_conn, nombre="Peso60",
                                region_id=region["id"])
-    b2 = _create_beneficiario(_test_db_conn, nombre="Peso80", folio="MX-002",
+    b2 = _create_beneficiario(_test_db_conn, nombre="Peso80",
                                region_id=region["id"])
 
     _create_estudio(_test_db_conn, b1["id"], tecnico_user["id"], "Sede A")
@@ -204,9 +203,9 @@ def test_tiene_foto_filter(client, _test_db_conn, tecnico_user, tecnico_headers)
     pais = _create_pais(_test_db_conn, "MX", "MX")
     region = _create_region(_test_db_conn, pais["id"], "Norte", "NTE")
 
-    b1 = _create_beneficiario(_test_db_conn, nombre="ConFoto", folio="MX-003",
+    b1 = _create_beneficiario(_test_db_conn, nombre="ConFoto",
                                region_id=region["id"])
-    b2 = _create_beneficiario(_test_db_conn, nombre="SinFoto", folio="MX-004",
+    b2 = _create_beneficiario(_test_db_conn, nombre="SinFoto",
                                region_id=region["id"])
 
     _create_estudio(_test_db_conn, b1["id"], tecnico_user["id"], "Sede X")

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -2651,6 +2651,10 @@
             control_cabeza: draftTecnica.control_cabeza || null,
             control_de_piernas: draftTecnica.control_de_piernas || null,
             padecimiento: draftTecnica.padecimiento || null,
+            soporte_oxigeno:
+              typeof draftTecnica.soporte_oxigeno === "boolean"
+                ? draftTecnica.soporte_oxigeno
+                : null,
             altura_total_in: draftTecnica.altura_total_in || null,
             peso_kg: draftTecnica.peso_kg || null,
             medida_cabeza_asiento: draftTecnica.medida_cabeza_asiento || null,
@@ -2662,6 +2666,9 @@
             unidad_peso_captura: draftTecnica.unidad_peso_captura || null,
             foto_path: draftTecnica.foto_path || null,
             foto_url: draftTecnica.foto_url || null,
+            equipo_solicitado: draftTecnica.equipo_solicitado || null,
+            estudio_clinico_path: draftTecnica.estudio_clinico_path || null,
+            estudio_clinico_url: draftTecnica.estudio_clinico_url || null,
             // Gestion
             entidad_solicitante: draftGestion.entidad_solicitante || null,
             prioridad: draftGestion.prioridad || null,
@@ -3946,6 +3953,13 @@
             unidad_medida: solicitud.unidad_captura || solicitud.unidad_medida || null,
             foto_url: solicitud.foto_url || null,
             foto_path: solicitud.foto_path || null,
+            soporte_oxigeno:
+              typeof solicitud.soporte_oxigeno === "boolean"
+                ? solicitud.soporte_oxigeno
+                : null,
+            equipo_solicitado: solicitud.equipo_solicitado || null,
+            estudio_clinico_path: solicitud.estudio_clinico_path || null,
+            estudio_clinico_url: solicitud.estudio_clinico_url || null,
           }));
 
         }

--- a/front/Capturista-view/tecnica.html
+++ b/front/Capturista-view/tecnica.html
@@ -859,8 +859,11 @@
       // resume path (which runs synchronously when there is no solicitud_id)
       // reads these to restore a previously uploaded photo.
       let capturedPhotoFile = null;
-      let uploadedPhotoUrl = null;        // canonical storage:// reference (DB)
-      let uploadedPhotoPreviewUrl = null; // browser-renderable URL (preview only)
+      let uploadedPhotoUrl = null;          // canonical storage:// reference (DB)
+      let uploadedPhotoPreviewUrl = null;   // browser-renderable URL (preview only)
+      let uploadedEstudioPath = null;       // storage path for estudio clínico (DB)
+      let uploadedEstudioUrl = null;        // canonical storage:// reference (DB)
+      let uploadedEstudioPreviewUrl = null; // browser-renderable URL (preview only)
 
       // Auth guard + Draft Resume
       (async function () {
@@ -918,6 +921,7 @@
               setVal("control_tronco", data.control_tronco);
               setVal("control_cabeza", data.control_cabeza);
               setVal("control_de_piernas", data.control_de_piernas);
+              setVal("equipo_solicitado", data.equipo_solicitado);
 
               // Set hidden technical field and restore selected padecimientos
               setVal("padecimiento", data.padecimiento);
@@ -974,6 +978,18 @@
                 renderPhotoPreviewCard();
               }
 
+              if (data.estudio_clinico_url) {
+                uploadedEstudioPath = data.estudio_clinico_path || null;
+                uploadedEstudioUrl = data.estudio_clinico_url;
+                uploadedEstudioPreviewUrl = data.estudio_clinico_url_resolved || null;
+                const guessedType = (data.estudio_clinico_path || "").toLowerCase().endsWith(".pdf")
+                  ? "application/pdf"
+                  : "image/jpeg";
+                setEstudioPreviewFromStoredUrl(uploadedEstudioPreviewUrl || data.estudio_clinico_url, guessedType);
+                renderEstudioStatus();
+                renderEstudioPreviewCard();
+              }
+
               // We've restored the draft, continue with the form
               return;
             } else if (res.status === 404) {
@@ -1001,6 +1017,7 @@
             setVal("control_tronco", data.control_tronco);
             setVal("control_cabeza", data.control_cabeza);
             setVal("control_de_piernas", data.control_de_piernas);
+            setVal("equipo_solicitado", data.equipo_solicitado);
             setVal("padecimiento", data.padecimiento);
             restorePadecimientosSelection(data.padecimiento);
             const oxiRadioB = document.querySelector(
@@ -1029,6 +1046,13 @@
             if (data.foto_url) {
               uploadedPhotoUrl = data.foto_url;
               uploadedPhotoPreviewUrl = data.foto_url_resolved || null;
+            }
+            // Similarly, restore estudio clínico state so the post-setup
+            // block can render the preview.
+            if (data.estudio_clinico_url) {
+              uploadedEstudioPath = data.estudio_clinico_path || null;
+              uploadedEstudioUrl = data.estudio_clinico_url;
+              uploadedEstudioPreviewUrl = data.estudio_clinico_url_resolved || null;
             }
           } catch (err) {
             console.error("Error loading localStorage draft:", err);
@@ -1310,6 +1334,14 @@
         estudioPreviewState.sourceUrl = null;
         estudioPreviewState.type = file.type || "image/jpeg";
         estudioPreviewState.name = file.name || "Estudio clínico";
+      }
+
+      function setEstudioPreviewFromStoredUrl(url, contentType) {
+        revokeEstudioPreviewUrl();
+        estudioPreviewState.objectUrl = null;
+        estudioPreviewState.sourceUrl = url || null;
+        estudioPreviewState.type = contentType || "image/jpeg";
+        estudioPreviewState.name = extractStoredFilename(url) || "Estudio clínico";
       }
 
       function renderEstudioPreviewCard() {
@@ -1730,6 +1762,36 @@
         return uploadedPhotoUrl;
       }
 
+      async function uploadEstudioClinico(fileInput) {
+        const file = capturedEstudioFile || fileInput?.files?.[0];
+        if (!file) return uploadedEstudioUrl || null;
+        const session = SessionGuard.getSession();
+        if (!session?.token) throw new Error("Sesión no válida.");
+        const formData = new FormData();
+        formData.append("archivo", file);
+        const res = await fetch("/api/upload-estudio-clinico", {
+          method: "POST",
+          headers: { Authorization: "Bearer " + session.token },
+          body: formData,
+        });
+        if (!res.ok) throw new Error("Error al subir el estudio clínico.");
+        const data = await res.json();
+        uploadedEstudioPath = data.estudio_clinico_path || null;
+        uploadedEstudioUrl = data.estudio_clinico_url || null;
+        uploadedEstudioPreviewUrl = data.estudio_clinico_url_resolved || data.estudio_clinico_url || null;
+        capturedEstudioFile = null;
+        if (fileInput) fileInput.value = "";
+        if (uploadedEstudioUrl) {
+          const guessedType = (file.name || "").toLowerCase().endsWith(".pdf")
+            ? "application/pdf"
+            : "image/jpeg";
+          setEstudioPreviewFromStoredUrl(uploadedEstudioPreviewUrl, guessedType);
+          renderEstudioStatus();
+          renderEstudioPreviewCard();
+        }
+        return uploadedEstudioUrl;
+      }
+
       function showSuccessModal({ title, description, onContinue }) {
         const modal = document.getElementById("success-modal");
         const titleEl = document.getElementById("success-modal-title");
@@ -1995,6 +2057,10 @@
           // foto_url_resolved is a browser-renderable URL kept only for preview.
           foto_url: uploadedPhotoUrl || null,
           foto_url_resolved: uploadedPhotoPreviewUrl || null,
+          equipo_solicitado: get("equipo_solicitado") || null,
+          estudio_clinico_path: uploadedEstudioPath || null,
+          estudio_clinico_url: uploadedEstudioUrl || null,
+          estudio_clinico_url_resolved: uploadedEstudioPreviewUrl || null,
         };
       }
 
@@ -2013,6 +2079,12 @@
           await uploadFoto(document.getElementById("file-upload"));
         } catch (err) {
           console.warn("No se pudo subir la foto antes de continuar:", err);
+        }
+        // Upload any pending estudio clínico so it isn't lost when navigating away.
+        try {
+          await uploadEstudioClinico(document.getElementById("estudio-clinico-file"));
+        } catch (err) {
+          console.warn("No se pudo subir el estudio clínico antes de continuar:", err);
         }
         const formData = getTecnicaFormData();
         localStorage.setItem("draft_tecnica", JSON.stringify(formData));
@@ -2035,6 +2107,11 @@
           await uploadFoto(document.getElementById("file-upload"));
         } catch (err) {
           console.warn("No se pudo subir la foto antes de regresar:", err);
+        }
+        try {
+          await uploadEstudioClinico(document.getElementById("estudio-clinico-file"));
+        } catch (err) {
+          console.warn("No se pudo subir el estudio clínico antes de regresar:", err);
         }
         // Save current form data before leaving
         const formData = getTecnicaFormData();
@@ -2078,6 +2155,13 @@
           } catch (err) {
             // Photo is optional for a borrador — keep going with whatever we had.
             console.warn("No se pudo subir la foto del borrador:", err);
+          }
+
+          // 1b. Upload any pending estudio clínico for the same reason.
+          try {
+            await uploadEstudioClinico(document.getElementById("estudio-clinico-file"));
+          } catch (err) {
+            console.warn("No se pudo subir el estudio clínico del borrador:", err);
           }
 
           // 2. Recolectar datos del formulario técnico actual
@@ -2176,6 +2260,9 @@
             unidad_medida: tecnicaData.unidad_medida || null,
             unidad_peso_captura: tecnicaData.unidad_peso_captura || null,
             foto_url: tecnicaData.foto_url || null,
+            equipo_solicitado: tecnicaData.equipo_solicitado || null,
+            estudio_clinico_path: tecnicaData.estudio_clinico_path || null,
+            estudio_clinico_url: tecnicaData.estudio_clinico_url || null,
             // Gestion (desde gestion)
             entidad_solicitante: draftGestion.entidad_solicitante || null,
             prioridad: draftGestion.prioridad || null,
@@ -2319,6 +2406,18 @@
           }
         }
 
+        // Upload estudio clínico if a new file was selected (optional for borrador)
+        try {
+          await uploadEstudioClinico(document.getElementById("estudio-clinico-file"));
+        } catch (err) {
+          if (status === "completo") {
+            errorEl.textContent = err.message || "Error al subir el estudio clínico.";
+            errorEl.classList.remove("hidden");
+            return;
+          }
+          console.warn("No se pudo subir el estudio clínico:", err);
+        }
+
         const payload = {
           beneficiario_id: beneficiarioId,
           entorno: get("entorno"),
@@ -2340,6 +2439,9 @@
           unidad_medida: (get("unidad_medida") === "metric" ? "cm" : "in"),
           unidad_peso_captura: (get("unidad_medida") === "metric" ? "kg" : "lb"),
           foto_url,
+          equipo_solicitado: get("equipo_solicitado") || null,
+          estudio_clinico_path: uploadedEstudioPath || null,
+          estudio_clinico_url: uploadedEstudioUrl || null,
           status,
         };
 
@@ -2692,6 +2794,15 @@
         setPhotoPreviewFromStoredUrl(uploadedPhotoPreviewUrl || uploadedPhotoUrl);
         renderPhotoStatus();
         renderPhotoPreviewCard();
+      }
+      // Render a stored estudio clínico set during localStorage-draft restore.
+      if (uploadedEstudioUrl && !estudioPreviewState.sourceUrl && !estudioPreviewState.objectUrl) {
+        const guessedType = (uploadedEstudioPath || "").toLowerCase().endsWith(".pdf")
+          ? "application/pdf"
+          : "image/jpeg";
+        setEstudioPreviewFromStoredUrl(uploadedEstudioPreviewUrl || uploadedEstudioUrl, guessedType);
+        renderEstudioStatus();
+        renderEstudioPreviewCard();
       }
       setupUnidadMedidaLabels();
       setupImageZoom();


### PR DESCRIPTION
## Summary

Two commits from the backend/DB audit:

### 40e4506 — feat(tecnica): persist equipo_solicitado and estudio clinico document
- Migration 0022 (applied live): adds `equipo_solicitado`, `estudio_clinico_path`, `estudio_clinico_url` to `solicitudes_tecnicas`.
- New `POST /api/upload-estudio-clinico` (jpeg/png/pdf, 10MB, bucket `documentos-estudio`).
- Wired end-to-end: tecnica form upload + restore, draft forwarding from socioeconomico, guardar-borrador payloads.
- Code-review fixes included: "Regresar" uploads pending document; final submit blocks on upload failure; draft cache forwards `soporte_oxigeno` + new fields; parameterized `_storage(bucket)`.

### ed8c2d3 — chore(db): drop dead columns and remove folio from backend runtime
- Migration 0023 (applied live): drops 8 columns with zero rows and no writer — `beneficiarios.folio`, `solicitudes_tecnicas.{estado_silla,lugar_entrega,fecha_entrega,requiere_soporte_oxigeno}`, `tutores.antiguedad`, `estudios_socioeconomicos.{otras_fuentes_ingreso,monto_otras_fuentes}`.
- Removes every runtime reference to `beneficiarios.folio` (INSERT, SELECTs, response models, search filters). CURP is the sole beneficiary identifier (Issue #32).
- Search now matches `nombre` + `curp_benef`; tecnica export uses CURP, matching admin export.

## Notes
- Both migrations are already applied to the live Supabase project.
- Frontend `folio` references are graceful fallbacks (`curp_benef || folio`) and needed no changes.
- Kept (future cleanup): `utils/folio.py` and the deprecated folio generator in `regiones.py` (they use `region_counters`, not the dropped column).