### PR TITLE
feat(auth): passwordless onboarding via invite email + password recovery flows

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -229,6 +229,27 @@ DDL = [
     "ALTER TABLE usuarios ADD COLUMN IF NOT EXISTS avatar_url TEXT",
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS soporte_oxigeno BOOLEAN NOT NULL DEFAULT FALSE",
     "ALTER TABLE solicitudes_tecnicas ADD COLUMN IF NOT EXISTS padecimiento TEXT",
+    # -----------------------------------------------------------------------
+    # Email onboarding / password self-service (migration 0024).
+    # Mirrored here (idempotently) so tests/conftest.py can build the test
+    # schema. The authoritative production DDL — including the app_runtime RLS
+    # policy that the test schema does not need — lives in
+    # backend/migrations/0024_password_tokens.sql.
+    # -----------------------------------------------------------------------
+    "ALTER TABLE usuarios ALTER COLUMN password_hash DROP NOT NULL",
+    """
+    CREATE TABLE IF NOT EXISTS password_tokens (
+        id           BIGSERIAL PRIMARY KEY,
+        usuario_id   INTEGER NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+        token_hash   TEXT NOT NULL UNIQUE,
+        tipo         TEXT NOT NULL CHECK (tipo IN ('invite', 'reset')),
+        expires_at   TIMESTAMPTZ NOT NULL,
+        used_at      TIMESTAMPTZ,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_password_tokens_hash ON password_tokens(token_hash)",
+    "CREATE INDEX IF NOT EXISTS idx_password_tokens_user_tipo ON password_tokens(usuario_id, tipo)",
 ]
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from env_bootstrap import load_root_env_if_needed
 
 load_root_env_if_needed(__file__)
 
-from routers import admin, auth, socioeconomico, tecnica, usuarios, regiones, perfiles, finalizar, guardar_borrador
+from routers import admin, auth, socioeconomico, tecnica, usuarios, regiones, perfiles, finalizar, guardar_borrador, password
 
 # Serve the frontend — path is resolved relative to this file so it works
 # both locally (uvicorn from backend/) and on Vercel (/var/task/backend/).
@@ -69,6 +69,7 @@ def create_app() -> FastAPI:
     app.include_router(perfiles.router, prefix="/api")
     app.include_router(finalizar.router, prefix="/api")
     app.include_router(guardar_borrador.router, prefix="/api")
+    app.include_router(password.router, prefix="/api")
 
     @app.get("/api/health")
     def health() -> JSONResponse:

--- a/backend/migrations/0024_password_tokens.sql
+++ b/backend/migrations/0024_password_tokens.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- Migration: 0024_password_tokens.sql
+-- Purpose:  Add password_tokens table for invite-activation and forgot-password
+--           reset flows. Tokens are stored as sha256 hex of the raw urlsafe
+--           token (raw token travels only in the URL/email, never in the DB).
+--           Also makes usuarios.password_hash NULLABLE so admin-created accounts
+--           can exist without a password until the user activates via invite link.
+--
+-- Background: Moving from admin-sets-password to verification-by-delivery.
+--             Account starts activo=FALSE with NULL password_hash; setting
+--             password via invite link activates the account (proves email
+--             ownership). Forgot-password uses tipo='reset', shorter TTL.
+--
+-- Environment variables consumed by the runtime (backend/utils/email.py):
+--   RESEND_API_KEY   — Bearer token for https://api.resend.com (required to send)
+--   EMAIL_FROM       — Sender address (default onboarding@resend.dev for dev)
+--   APP_BASE_URL     — Base URL used to build activation/reset links in emails
+--
+-- This is ADDITIVE only (per migrations/README.md rule #3):
+--   - New table: password_tokens
+--   - ALTER TABLE usuarios: password_hash DROP NOT NULL
+--   Both are safe for existing active users (all have non-null password_hash;
+--   removing the constraint does not change existing data or behavior).
+--
+-- FOOTGUN: New table requires its own app_runtime_all RLS policy (app_runtime
+--          is NOBYPASSRLS — see 0014). Included in this migration.
+-- ============================================================================
+
+BEGIN;
+
+-- 1. Make password_hash nullable (additive — no existing data changes)
+ALTER TABLE public.usuarios
+    ALTER COLUMN password_hash DROP NOT NULL;
+
+-- 2. Token store
+CREATE TABLE IF NOT EXISTS public.password_tokens (
+    id           BIGSERIAL PRIMARY KEY,
+    usuario_id   INTEGER   NOT NULL
+                           REFERENCES public.usuarios(id) ON DELETE CASCADE,
+    token_hash   TEXT      NOT NULL UNIQUE,          -- sha256 hex of raw urlsafe token
+    tipo         TEXT      NOT NULL
+                           CHECK (tipo IN ('invite', 'reset')),
+    expires_at   TIMESTAMPTZ NOT NULL,
+    used_at      TIMESTAMPTZ,                        -- NULL = unused; set on redemption
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 3. Indexes
+--    Primary lookup: hash (always queried by exact hash)
+CREATE INDEX IF NOT EXISTS idx_password_tokens_hash
+    ON public.password_tokens (token_hash);
+
+--    Compound: invalidate prior tokens of same (usuario_id, tipo) on resend
+CREATE INDEX IF NOT EXISTS idx_password_tokens_user_tipo
+    ON public.password_tokens (usuario_id, tipo);
+
+-- 4. RLS (FOOTGUN — mandatory for app_runtime NOBYPASSRLS role)
+ALTER TABLE public.password_tokens ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS app_runtime_all ON public.password_tokens;
+CREATE POLICY app_runtime_all ON public.password_tokens
+    FOR ALL TO app_runtime
+    USING (true)
+    WITH CHECK (true);
+
+COMMIT;

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -83,7 +83,14 @@ def _create_jwt(usuario_id: int, rol: str) -> str:
     return jwt.encode(payload, _JWT_SECRET, algorithm=_JWT_ALGORITHM)
 
 
-def _verify_password(plain: str, hashed: str) -> bool:
+def _verify_password(plain: str, hashed: str | None) -> bool:
+    # A NULL/empty hash (a Pendiente account created via invite, not yet
+    # activated) must NEVER authenticate. Return False without invoking bcrypt.
+    # Defense-in-depth: the activo=FALSE gate already blocks these users, but
+    # this guard protects against a future gate bypass. See spec: NULL Hash
+    # Hardening.
+    if not hashed:
+        return False
     try:
         return _pwd_context.verify(plain, hashed)
     except UnknownHashError:

--- a/backend/routers/password.py
+++ b/backend/routers/password.py
@@ -110,14 +110,16 @@ def _issue_token(db: _DBAdapter, usuario_id: int, tipo: str, ttl_sql: str) -> st
 
 
 def _redeem_token(db: _DBAdapter, token: str, tipo: str) -> dict:
-    """Look up a valid, unused, non-expired token of the given tipo. Returns the
-    token row (with usuario_id). Raises 400 when invalid/expired/used/wrong-tipo."""
+    """Atomically consume a valid, unused, non-expired token of the given tipo
+    (single UPDATE avoids a select-then-update race on concurrent redemption).
+    Returns the token row (with usuario_id). Raises 400 when
+    invalid/expired/used/wrong-tipo."""
     row = db.execute(
         """
-        SELECT id, usuario_id
-        FROM password_tokens
+        UPDATE password_tokens SET used_at = NOW()
         WHERE token_hash = %s AND tipo = %s
           AND used_at IS NULL AND expires_at > NOW()
+        RETURNING id, usuario_id
         """,
         (hash_token(token), tipo),
     ).fetchone()
@@ -152,7 +154,7 @@ def reenviar_invitacion(
     """Resend an invite for a Pendiente user (activo=FALSE, password_hash NULL).
     Admin only. Fail-open on email delivery."""
     user = db.execute(
-        "SELECT id, email, activo, password_hash FROM usuarios WHERE id = %s",
+        "SELECT id, nombre, email, activo, password_hash FROM usuarios WHERE id = %s",
         (usuario_id,),
     ).fetchone()
     if user is None:
@@ -166,7 +168,7 @@ def reenviar_invitacion(
 
     raw_token = _issue_token(db, usuario_id, "invite", INVITE_TTL_SQL)
     try:
-        send_invite(user["email"], raw_token)
+        send_invite(user["email"], raw_token, user["nombre"])
     except EmailDeliveryError:
         logger.warning(
             "Invite resend email delivery failed for usuario_id=%s; user remains "
@@ -226,10 +228,6 @@ def set_password(
         "UPDATE usuarios SET password_hash = %s, activo = TRUE WHERE id = %s",
         (_hash_password(body.password), token_row["usuario_id"]),
     )
-    db.execute(
-        "UPDATE password_tokens SET used_at = NOW() WHERE id = %s",
-        (token_row["id"],),
-    )
     return MessageResponse(message="Contraseña establecida. Ya podés iniciar sesión.")
 
 
@@ -245,10 +243,6 @@ def reset_password(
     db.execute(
         "UPDATE usuarios SET password_hash = %s WHERE id = %s",
         (_hash_password(body.password), token_row["usuario_id"]),
-    )
-    db.execute(
-        "UPDATE password_tokens SET used_at = NOW() WHERE id = %s",
-        (token_row["id"],),
     )
     return MessageResponse(message="Contraseña actualizada. Ya podés iniciar sesión.")
 

--- a/backend/routers/password.py
+++ b/backend/routers/password.py
@@ -1,0 +1,285 @@
+"""
+Password / token flows router (v2).
+
+All token-redemption flows and the authenticated change-password endpoint live
+here (see design ADR-1), mounted under /api in main.py:
+
+- POST /api/usuarios/{id}/reenviar-invitacion  — admin resends an invite (204)
+- POST /api/auth/forgot-password                — public, enumeration-safe (200)
+- POST /api/auth/set-password                   — public, invite activation (200)
+- POST /api/auth/reset-password                 — public, reset for active user (200)
+- POST /api/me/password                         — authenticated change password (204)
+
+Token mechanics (see utils/tokens.py):
+  - raw token = secrets.token_urlsafe(32); only its sha256 hex is stored.
+  - single-use (used_at stamped on redemption), typed (tipo invite|reset),
+    time-bound (invite 72h, reset 1h). Lookups always filter by exact hash,
+    tipo, used_at IS NULL and expires_at > NOW().
+"""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, EmailStr, field_validator
+
+from database import get_db, _DBAdapter
+from routers.auth import (
+    CurrentUser,
+    require_admin,
+    require_auth,
+    _hash_password,
+    _verify_password,
+)
+from utils.email import EmailDeliveryError, send_invite, send_reset
+from utils.tokens import (
+    INVITE_TTL_SQL,
+    RESET_TTL_SQL,
+    generate_raw_token,
+    hash_token,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_GENERIC_FORGOT_MESSAGE = "Si el email existe, recibirás instrucciones en breve."
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+def _validate_min_8(v: str) -> str:
+    if len(v) < 8:
+        raise ValueError("La contraseña debe tener al menos 8 caracteres")
+    return v
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class TokenPasswordRequest(BaseModel):
+    token: str
+    password: str
+
+    @field_validator("password")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        return _validate_min_8(v)
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def new_password_min_length(cls, v: str) -> str:
+        return _validate_min_8(v)
+
+
+class MessageResponse(BaseModel):
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _issue_token(db: _DBAdapter, usuario_id: int, tipo: str, ttl_sql: str) -> str:
+    """Invalidate prior active tokens of the same (usuario_id, tipo), then insert
+    a fresh one. Returns the raw token (only its hash is stored)."""
+    db.execute(
+        """
+        UPDATE password_tokens SET used_at = NOW()
+        WHERE usuario_id = %s AND tipo = %s AND used_at IS NULL
+        """,
+        (usuario_id, tipo),
+    )
+    raw_token = generate_raw_token()
+    db.execute(
+        f"""
+        INSERT INTO password_tokens (usuario_id, token_hash, tipo, expires_at)
+        VALUES (%s, %s, %s, NOW() + INTERVAL '{ttl_sql}')
+        """,
+        (usuario_id, hash_token(raw_token), tipo),
+    )
+    return raw_token
+
+
+def _redeem_token(db: _DBAdapter, token: str, tipo: str) -> dict:
+    """Look up a valid, unused, non-expired token of the given tipo. Returns the
+    token row (with usuario_id). Raises 400 when invalid/expired/used/wrong-tipo."""
+    row = db.execute(
+        """
+        SELECT id, usuario_id
+        FROM password_tokens
+        WHERE token_hash = %s AND tipo = %s
+          AND used_at IS NULL AND expires_at > NOW()
+        """,
+        (hash_token(token), tipo),
+    ).fetchone()
+    if row is None:
+        if tipo == "invite":
+            detail = (
+                "El enlace es inválido o ha expirado. Solicitá una nueva "
+                "invitación al administrador."
+            )
+        else:
+            detail = (
+                "El enlace es inválido o ha expirado. Solicitá un nuevo enlace "
+                "desde la pantalla de inicio de sesión."
+            )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/usuarios/{usuario_id}/reenviar-invitacion",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def reenviar_invitacion(
+    usuario_id: int,
+    db: Annotated[_DBAdapter, Depends(get_db)],
+    _admin: Annotated[CurrentUser, Depends(require_admin)],
+) -> None:
+    """Resend an invite for a Pendiente user (activo=FALSE, password_hash NULL).
+    Admin only. Fail-open on email delivery."""
+    user = db.execute(
+        "SELECT id, email, activo, password_hash FROM usuarios WHERE id = %s",
+        (usuario_id,),
+    ).fetchone()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Usuario no encontrado"
+        )
+    if user["activo"] or user["password_hash"] is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="El usuario ya está activo."
+        )
+
+    raw_token = _issue_token(db, usuario_id, "invite", INVITE_TTL_SQL)
+    try:
+        send_invite(user["email"], raw_token)
+    except EmailDeliveryError:
+        logger.warning(
+            "Invite resend email delivery failed for usuario_id=%s; user remains "
+            "Pendiente.",
+            usuario_id,
+        )
+    return None
+
+
+@router.post("/auth/forgot-password", response_model=MessageResponse)
+def forgot_password(
+    body: ForgotPasswordRequest,
+    db: Annotated[_DBAdapter, Depends(get_db)],
+) -> MessageResponse:
+    """Enumeration-safe: always returns the same 200 message. A reset token is
+    issued and emailed ONLY for an existing active user."""
+    user = db.execute(
+        "SELECT id, email, activo FROM usuarios WHERE email = %s",
+        (body.email.lower().strip(),),
+    ).fetchone()
+
+    if user is not None and user["activo"]:
+        raw_token = _issue_token(db, user["id"], "reset", RESET_TTL_SQL)
+        try:
+            send_reset(user["email"], raw_token)
+        except EmailDeliveryError:
+            logger.warning(
+                "Reset email delivery failed for usuario_id=%s.", user["id"]
+            )
+
+    return MessageResponse(message=_GENERIC_FORGOT_MESSAGE)
+
+
+@router.post("/auth/set-password", response_model=MessageResponse)
+def set_password(
+    body: TokenPasswordRequest,
+    db: Annotated[_DBAdapter, Depends(get_db)],
+) -> MessageResponse:
+    """Activate a Pendiente account via a valid invite token: set the password
+    (bcrypt) and activo=TRUE, then consume the token."""
+    token_row = _redeem_token(db, body.token, "invite")
+
+    # Guard: the token must belong to a still-Pendiente account. A user who was
+    # later given a password / deactivated cannot be re-activated via an old
+    # invite link.
+    user = db.execute(
+        "SELECT id, activo, password_hash FROM usuarios WHERE id = %s",
+        (token_row["usuario_id"],),
+    ).fetchone()
+    if user is None or user["activo"] or user["password_hash"] is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cuenta deshabilitada. Contactá al administrador.",
+        )
+
+    db.execute(
+        "UPDATE usuarios SET password_hash = %s, activo = TRUE WHERE id = %s",
+        (_hash_password(body.password), token_row["usuario_id"]),
+    )
+    db.execute(
+        "UPDATE password_tokens SET used_at = NOW() WHERE id = %s",
+        (token_row["id"],),
+    )
+    return MessageResponse(message="Contraseña establecida. Ya podés iniciar sesión.")
+
+
+@router.post("/auth/reset-password", response_model=MessageResponse)
+def reset_password(
+    body: TokenPasswordRequest,
+    db: Annotated[_DBAdapter, Depends(get_db)],
+) -> MessageResponse:
+    """Reset the password of an active user via a valid reset token. Does NOT
+    change activo."""
+    token_row = _redeem_token(db, body.token, "reset")
+
+    db.execute(
+        "UPDATE usuarios SET password_hash = %s WHERE id = %s",
+        (_hash_password(body.password), token_row["usuario_id"]),
+    )
+    db.execute(
+        "UPDATE password_tokens SET used_at = NOW() WHERE id = %s",
+        (token_row["id"],),
+    )
+    return MessageResponse(message="Contraseña actualizada. Ya podés iniciar sesión.")
+
+
+@router.post("/me/password", status_code=status.HTTP_204_NO_CONTENT)
+def change_password(
+    body: ChangePasswordRequest,
+    db: Annotated[_DBAdapter, Depends(get_db)],
+    user: Annotated[CurrentUser, Depends(require_auth)],
+) -> None:
+    """Authenticated password change for any of the 4 roles. Verifies the
+    current password before applying the change."""
+    row = db.execute(
+        "SELECT password_hash FROM usuarios WHERE id = %s",
+        (user.usuario_id,),
+    ).fetchone()
+
+    if row is None or row["password_hash"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tu cuenta aún no tiene contraseña establecida. Usá el enlace de invitación.",
+        )
+
+    if not _verify_password(body.current_password, row["password_hash"]):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="La contraseña actual es incorrecta.",
+        )
+
+    db.execute(
+        "UPDATE usuarios SET password_hash = %s WHERE id = %s",
+        (_hash_password(body.new_password), user.usuario_id),
+    )
+    return None

--- a/backend/routers/usuarios.py
+++ b/backend/routers/usuarios.py
@@ -186,7 +186,7 @@ def create_usuario(
             (row["id"], hash_token(raw_token)),
         )
         try:
-            send_invite(row["email"], raw_token)
+            send_invite(row["email"], raw_token, row["nombre"])
         except EmailDeliveryError:
             logger.warning(
                 "Invite email delivery failed for usuario_id=%s; user remains "

--- a/backend/routers/usuarios.py
+++ b/backend/routers/usuarios.py
@@ -9,7 +9,8 @@ Endpoints:
 - DELETE /api/usuarios/{id}?permanent=true  — Hard delete user; 409 if referenced (admin)
 """
 
-from typing import Annotated
+import logging
+from typing import Annotated, Optional
 
 import psycopg2  # noqa: F401  — used for FK violation detection
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -17,6 +18,10 @@ from pydantic import BaseModel, EmailStr, field_validator
 
 from database import get_db, _DBAdapter
 from routers.auth import CurrentUser, require_admin, _hash_password
+from utils.email import EmailDeliveryError, send_invite
+from utils.tokens import INVITE_TTL_SQL, generate_raw_token, hash_token
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -30,7 +35,11 @@ _VALID_ROLES = {"admin", "capturista", "tecnico", "organizacion"}
 class UsuarioCreateRequest(BaseModel):
     nombre: str
     email: EmailStr
-    password: str
+    # Optional: when omitted (the new default), the user is created passwordless
+    # (activo=FALSE, password_hash=NULL) and an invite email is sent so they set
+    # their own password. When provided (legacy path), the account is created
+    # active with that password — kept for backward compatibility.
+    password: Optional[str] = None
     rol: str
 
     @field_validator("nombre")
@@ -43,7 +52,9 @@ class UsuarioCreateRequest(BaseModel):
 
     @field_validator("password")
     @classmethod
-    def password_min_length(cls, v: str) -> str:
+    def password_min_length(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
         if len(v) < 8:
             raise ValueError("La contraseña debe tener al menos 8 caracteres")
         return v
@@ -63,6 +74,9 @@ class UsuarioResponse(BaseModel):
     rol: str
     activo: bool
     organizacion_id: int | None = None
+    # True when the account was created via invite and has not been activated
+    # yet (activo=FALSE AND password_hash IS NULL). Derived server-side.
+    pending: bool = False
 
 
 class UsuarioUpdateRequest(BaseModel):
@@ -129,19 +143,56 @@ def create_usuario(
             detail="El email ya está registrado",
         )
 
-    password_hash = _hash_password(body.password)
+    # Two creation paths:
+    #  - Legacy (password provided): hash it, account is active immediately.
+    #  - Invite (no password): password_hash=NULL, activo=FALSE, then email a
+    #    one-time invite link so the user sets their own password (proving email
+    #    ownership). The account stays Pendiente until activation.
+    invite_flow = body.password is None
 
-    row = db.execute(
-        """
-        INSERT INTO usuarios (nombre, email, password_hash, rol)
-        VALUES (%s, %s, %s, %s)
-        RETURNING id, nombre, email, rol, activo
-        """,
-        (body.nombre.strip(), body.email.lower(), password_hash, body.rol),
-    ).fetchone()
+    if invite_flow:
+        row = db.execute(
+            """
+            INSERT INTO usuarios (nombre, email, password_hash, rol, activo)
+            VALUES (%s, %s, NULL, %s, FALSE)
+            RETURNING id, nombre, email, rol, activo
+            """,
+            (body.nombre.strip(), body.email.lower(), body.rol),
+        ).fetchone()
+    else:
+        password_hash = _hash_password(body.password)
+        row = db.execute(
+            """
+            INSERT INTO usuarios (nombre, email, password_hash, rol)
+            VALUES (%s, %s, %s, %s)
+            RETURNING id, nombre, email, rol, activo
+            """,
+            (body.nombre.strip(), body.email.lower(), password_hash, body.rol),
+        ).fetchone()
 
     if row is None:
         raise HTTPException(status_code=500, detail="Error al crear el usuario")
+
+    # Invite path: issue a single-use invite token (72h) and email it.
+    # Fail-open — if delivery fails the user stays Pendiente and an admin can
+    # resend via POST /usuarios/{id}/reenviar-invitacion.
+    if invite_flow:
+        raw_token = generate_raw_token()
+        db.execute(
+            f"""
+            INSERT INTO password_tokens (usuario_id, token_hash, tipo, expires_at)
+            VALUES (%s, %s, 'invite', NOW() + INTERVAL '{INVITE_TTL_SQL}')
+            """,
+            (row["id"], hash_token(raw_token)),
+        )
+        try:
+            send_invite(row["email"], raw_token)
+        except EmailDeliveryError:
+            logger.warning(
+                "Invite email delivery failed for usuario_id=%s; user remains "
+                "Pendiente until an admin resends the invitation.",
+                row["id"],
+            )
 
     # If creating an organization user, auto-create the organizaciones entry
     # and add the user as a leader so /api/me/perfil resolves correctly
@@ -166,6 +217,7 @@ def create_usuario(
         email=row["email"],
         rol=row["rol"],
         activo=row["activo"],
+        pending=invite_flow,
     )
 
 
@@ -178,6 +230,7 @@ def list_usuarios(
     rows = db.execute(
         """
         SELECT u.id, u.nombre, u.email, u.rol, u.activo,
+               (u.password_hash IS NULL AND NOT u.activo) AS pending,
                (
                    SELECT MIN(ol.organizacion_id)
                    FROM organizaciones_lideres ol
@@ -196,6 +249,7 @@ def list_usuarios(
             rol=row["rol"],
             activo=row["activo"],
             organizacion_id=row["organizacion_id"],
+            pending=row["pending"],
         )
         for row in rows
     ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -182,6 +182,9 @@ _TABLES_ORDER = [
     "regiones",
     "paises",
     "organizaciones",
+    # password_tokens has a FK to usuarios (ON DELETE CASCADE); it must be
+    # cleaned up BEFORE usuarios so the DELETE order respects the constraint.
+    "password_tokens",
     "usuarios",
 ]
 

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -44,7 +44,7 @@ class TestSendInvite:
         body = kwargs["json"]
         assert body["from"] == "onboarding@resend.dev"
         assert body["to"] == ["user@example.com"]
-        assert body["subject"] == "Bienvenido/a — Activá tu cuenta"
+        assert body["subject"] == "Bienvenido/a — Activa tu cuenta"
         # Activation link points at set-password.html with the raw token.
         assert "https://app.example.com/set-password.html?token=raw-token-abc" in body["html"]
         assert "72 horas" in body["html"]

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for backend/utils/email.py.
+
+TDD: tests written BEFORE wiring the email module into the routers.
+These never hit the network — httpx.post is mocked. They assert the request
+shape (endpoint, auth header, from/to/subject/html) and that EmailDeliveryError
+is raised on timeout and HTTP errors so call sites can fail-open.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from utils import email as email_mod
+from utils.email import EmailDeliveryError, send_invite, send_reset
+
+
+@pytest.fixture(autouse=True)
+def _email_env(monkeypatch):
+    """Deterministic email env for every test in this module."""
+    monkeypatch.setenv("RESEND_API_KEY", "test-resend-key")
+    monkeypatch.setenv("EMAIL_FROM", "onboarding@resend.dev")
+    monkeypatch.setenv("APP_BASE_URL", "https://app.example.com")
+
+
+def _ok_response() -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestSendInvite:
+    def test_posts_to_resend_with_auth_and_body(self):
+        with patch.object(email_mod.httpx, "post", return_value=_ok_response()) as mock_post:
+            send_invite("user@example.com", "raw-token-abc")
+
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://api.resend.com/emails"
+        assert kwargs["headers"]["Authorization"] == "Bearer test-resend-key"
+        assert kwargs["timeout"] == 10.0
+        body = kwargs["json"]
+        assert body["from"] == "onboarding@resend.dev"
+        assert body["to"] == ["user@example.com"]
+        assert body["subject"] == "Bienvenido/a — Activá tu cuenta"
+        # Activation link points at set-password.html with the raw token.
+        assert "https://app.example.com/set-password.html?token=raw-token-abc" in body["html"]
+        assert "72 horas" in body["html"]
+
+    def test_relative_link_when_base_url_unset(self, monkeypatch):
+        monkeypatch.delenv("APP_BASE_URL", raising=False)
+        with patch.object(email_mod.httpx, "post", return_value=_ok_response()) as mock_post:
+            send_invite("user@example.com", "tok")
+        body = mock_post.call_args.kwargs["json"]
+        assert body["html"].count("/set-password.html?token=tok") == 1
+
+
+class TestSendReset:
+    def test_posts_reset_body(self):
+        with patch.object(email_mod.httpx, "post", return_value=_ok_response()) as mock_post:
+            send_reset("user@example.com", "reset-token-xyz")
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["subject"] == "Recuperación de contraseña"
+        assert "https://app.example.com/reset-password.html?token=reset-token-xyz" in body["html"]
+        assert "1 hora" in body["html"]
+
+
+class TestFailureModes:
+    def test_timeout_raises_email_delivery_error(self):
+        with patch.object(email_mod.httpx, "post", side_effect=httpx.TimeoutException("boom")):
+            with pytest.raises(EmailDeliveryError):
+                send_invite("user@example.com", "tok")
+
+    def test_http_error_raises_email_delivery_error(self):
+        resp = MagicMock()
+        err = httpx.HTTPStatusError("bad", request=MagicMock(), response=MagicMock(status_code=500))
+        resp.raise_for_status.side_effect = err
+        with patch.object(email_mod.httpx, "post", return_value=resp):
+            with pytest.raises(EmailDeliveryError):
+                send_reset("user@example.com", "tok")
+
+    def test_transport_error_raises_email_delivery_error(self):
+        with patch.object(email_mod.httpx, "post", side_effect=httpx.ConnectError("no route")):
+            with pytest.raises(EmailDeliveryError):
+                send_invite("user@example.com", "tok")

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -34,7 +34,7 @@ def _ok_response() -> MagicMock:
 class TestSendInvite:
     def test_posts_to_resend_with_auth_and_body(self):
         with patch.object(email_mod.httpx, "post", return_value=_ok_response()) as mock_post:
-            send_invite("user@example.com", "raw-token-abc")
+            send_invite("user@example.com", "raw-token-abc", "Ana Pérez")
 
         mock_post.assert_called_once()
         args, kwargs = mock_post.call_args
@@ -48,11 +48,13 @@ class TestSendInvite:
         # Activation link points at set-password.html with the raw token.
         assert "https://app.example.com/set-password.html?token=raw-token-abc" in body["html"]
         assert "72 horas" in body["html"]
+        # Personalized greeting with the user's name (spec requirement).
+        assert "Ana Pérez" in body["html"]
 
     def test_relative_link_when_base_url_unset(self, monkeypatch):
         monkeypatch.delenv("APP_BASE_URL", raising=False)
         with patch.object(email_mod.httpx, "post", return_value=_ok_response()) as mock_post:
-            send_invite("user@example.com", "tok")
+            send_invite("user@example.com", "tok", "Ana")
         body = mock_post.call_args.kwargs["json"]
         assert body["html"].count("/set-password.html?token=tok") == 1
 
@@ -72,7 +74,7 @@ class TestFailureModes:
     def test_timeout_raises_email_delivery_error(self):
         with patch.object(email_mod.httpx, "post", side_effect=httpx.TimeoutException("boom")):
             with pytest.raises(EmailDeliveryError):
-                send_invite("user@example.com", "tok")
+                send_invite("user@example.com", "tok", "Ana")
 
     def test_http_error_raises_email_delivery_error(self):
         resp = MagicMock()
@@ -85,4 +87,4 @@ class TestFailureModes:
     def test_transport_error_raises_email_delivery_error(self):
         with patch.object(email_mod.httpx, "post", side_effect=httpx.ConnectError("no route")):
             with pytest.raises(EmailDeliveryError):
-                send_invite("user@example.com", "tok")
+                send_invite("user@example.com", "tok", "Ana")

--- a/backend/tests/test_password_flows.py
+++ b/backend/tests/test_password_flows.py
@@ -118,13 +118,9 @@ class TestSetPassword:
         assert _token_used_at(_test_db_conn, raw) is not None
 
     def test_valid_token_then_login(self, client, admin_headers):
-        _create_pending_user(client, admin_headers, "setpwlogin@test.mx")
-        # Re-fetch the raw token from the create mock is not available here; issue
-        # a fresh invite via resend to capture the raw token cleanly.
-        # (create above already consumed the mock context.)
-        uid, raw = _create_pending_user(client, admin_headers, "setpwlogin2@test.mx")
+        uid, raw = _create_pending_user(client, admin_headers, "setpwlogin@test.mx")
         client.post("/api/auth/set-password", json={"token": raw, "password": "loginpass123"})
-        login = client.post("/api/auth/login", json={"email": "setpwlogin2@test.mx", "password": "loginpass123"})
+        login = client.post("/api/auth/login", json={"email": "setpwlogin@test.mx", "password": "loginpass123"})
         assert login.status_code == 200
         assert "access_token" in login.json()
 

--- a/backend/tests/test_password_flows.py
+++ b/backend/tests/test_password_flows.py
@@ -1,0 +1,307 @@
+"""
+Integration tests for the email-onboarding / password self-service flows.
+
+TDD: tests written alongside routers/password.py. Email delivery is always
+mocked (no Resend calls). Expiry/used-token scenarios use direct DB inserts of
+tokens with a controlled raw value (we store only its sha256 hash) rather than
+sleeping or patching the clock.
+
+Covers:
+- Resend invitation (admin-only, Pendiente-only, 409 on active)
+- Set-password activation (tipo-lock, expiry, single-use, deactivated guard)
+- Forgot/reset (enumeration-safe, tipo-lock, expiry, invalidation on reissue)
+- Change password (all 4 roles, wrong-current, too-short, unauthenticated)
+- _verify_password NULL/empty-hash hardening
+"""
+
+from unittest.mock import patch
+
+import psycopg2.extras
+import pytest
+
+from routers.auth import _verify_password
+from utils.tokens import hash_token
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_pending_user(client, admin_headers, email, rol="capturista"):
+    """Create a passwordless (Pendiente) user; return (usuario_id, raw_token)."""
+    with patch("routers.usuarios.send_invite") as mock_invite:
+        res = client.post("/api/usuarios", json={
+            "nombre": "Pendiente Test",
+            "email": email,
+            "rol": rol,
+        }, headers=admin_headers)
+    assert res.status_code == 201, res.text
+    raw_token = mock_invite.call_args.args[1]
+    return res.json()["usuario_id"], raw_token
+
+
+def _insert_token(conn, usuario_id, raw, tipo, interval, used=False):
+    """Insert a token directly with a controlled raw value and relative expiry.
+
+    `interval` is a Postgres interval string, e.g. '72 hours' or '-1 hour'
+    (negative → already expired). `used=True` stamps used_at=NOW().
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO password_tokens (usuario_id, token_hash, tipo, expires_at, used_at)
+            VALUES (%s, %s, %s, NOW() + %s::interval,
+                    CASE WHEN %s THEN NOW() ELSE NULL END)
+            """,
+            (usuario_id, hash_token(raw), tipo, interval, used),
+        )
+    conn.commit()
+
+
+def _token_used_at(conn, raw):
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute("SELECT used_at FROM password_tokens WHERE token_hash = %s", (hash_token(raw),))
+        row = cur.fetchone()
+    conn.commit()
+    return row["used_at"] if row else "MISSING"
+
+
+# ---------------------------------------------------------------------------
+# Resend invitation
+# ---------------------------------------------------------------------------
+
+class TestResendInvitation:
+    def test_reenviar_invite_non_admin_403(self, client, capturista_headers, admin_headers):
+        uid, _ = _create_pending_user(client, admin_headers, "resend403@test.mx")
+        res = client.post(f"/api/usuarios/{uid}/reenviar-invitacion", headers=capturista_headers)
+        assert res.status_code == 403
+
+    def test_reenviar_invite_admin_204_invalidates_prior(self, client, admin_headers, _test_db_conn):
+        uid, first_raw = _create_pending_user(client, admin_headers, "resend204@test.mx")
+        with patch("routers.password.send_invite") as mock_invite:
+            res = client.post(f"/api/usuarios/{uid}/reenviar-invitacion", headers=admin_headers)
+        assert res.status_code == 204
+        mock_invite.assert_called_once()
+        # Prior invite token invalidated (used_at stamped).
+        assert _token_used_at(_test_db_conn, first_raw) is not None
+        # New token issued and still unused.
+        new_raw = mock_invite.call_args.args[1]
+        assert _token_used_at(_test_db_conn, new_raw) is None
+
+    def test_reenviar_invite_active_user_409(self, client, admin_headers, capturista_user):
+        # capturista_user is created active (with password) by the fixture.
+        res = client.post(f"/api/usuarios/{capturista_user['id']}/reenviar-invitacion", headers=admin_headers)
+        assert res.status_code == 409
+        assert "activo" in res.json()["detail"].lower()
+
+    def test_reenviar_invite_404_missing_user(self, client, admin_headers):
+        res = client.post("/api/usuarios/99999/reenviar-invitacion", headers=admin_headers)
+        assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Set-password activation
+# ---------------------------------------------------------------------------
+
+class TestSetPassword:
+    def test_valid_token_activates_account(self, client, admin_headers, _test_db_conn):
+        uid, raw = _create_pending_user(client, admin_headers, "setpw@test.mx")
+        res = client.post("/api/auth/set-password", json={"token": raw, "password": "brandnew123"})
+        assert res.status_code == 200
+        # Account is now active and token consumed.
+        with _test_db_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT activo, password_hash FROM usuarios WHERE id = %s", (uid,))
+            user = cur.fetchone()
+        _test_db_conn.commit()
+        assert user["activo"] is True
+        assert user["password_hash"] is not None
+        assert _token_used_at(_test_db_conn, raw) is not None
+
+    def test_valid_token_then_login(self, client, admin_headers):
+        _create_pending_user(client, admin_headers, "setpwlogin@test.mx")
+        # Re-fetch the raw token from the create mock is not available here; issue
+        # a fresh invite via resend to capture the raw token cleanly.
+        # (create above already consumed the mock context.)
+        uid, raw = _create_pending_user(client, admin_headers, "setpwlogin2@test.mx")
+        client.post("/api/auth/set-password", json={"token": raw, "password": "loginpass123"})
+        login = client.post("/api/auth/login", json={"email": "setpwlogin2@test.mx", "password": "loginpass123"})
+        assert login.status_code == 200
+        assert "access_token" in login.json()
+
+    def test_expired_token_400_not_consumed(self, client, admin_headers, _test_db_conn):
+        uid, _ = _create_pending_user(client, admin_headers, "setpwexp@test.mx")
+        raw = "expired-invite-token"
+        _insert_token(_test_db_conn, uid, raw, "invite", "-1 hour")
+        res = client.post("/api/auth/set-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+        assert _token_used_at(_test_db_conn, raw) is None  # not consumed
+
+    def test_already_used_token_400(self, client, admin_headers, _test_db_conn):
+        uid, _ = _create_pending_user(client, admin_headers, "setpwused@test.mx")
+        raw = "used-invite-token"
+        _insert_token(_test_db_conn, uid, raw, "invite", "72 hours", used=True)
+        res = client.post("/api/auth/set-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+
+    def test_wrong_tipo_400(self, client, admin_headers, _test_db_conn):
+        """A reset token must not redeem on the set-password (invite) path."""
+        uid, _ = _create_pending_user(client, admin_headers, "setpwtipo@test.mx")
+        raw = "reset-token-on-invite-path"
+        _insert_token(_test_db_conn, uid, raw, "reset", "72 hours")
+        res = client.post("/api/auth/set-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+
+    def test_deactivated_user_400(self, client, admin_headers, capturista_user, _test_db_conn):
+        """An invite token pointing at a user who already has a password (active
+        or later deactivated) must not re-activate the account."""
+        raw = "invite-for-active-user"
+        _insert_token(_test_db_conn, capturista_user["id"], raw, "invite", "72 hours")
+        res = client.post("/api/auth/set-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+
+    def test_password_too_short_422(self, client, admin_headers):
+        uid, raw = _create_pending_user(client, admin_headers, "setpwshort@test.mx")
+        res = client.post("/api/auth/set-password", json={"token": raw, "password": "short"})
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Forgot / reset
+# ---------------------------------------------------------------------------
+
+class TestForgotReset:
+    def test_forgot_known_active_email_200_sends(self, client, capturista_user, _test_db_conn):
+        with patch("routers.password.send_reset") as mock_reset:
+            res = client.post("/api/auth/forgot-password", json={"email": "cap@test.mx"})
+        assert res.status_code == 200
+        mock_reset.assert_called_once()
+        raw = mock_reset.call_args.args[1]
+        assert _token_used_at(_test_db_conn, raw) is None
+
+    def test_forgot_unknown_email_200_identical_no_token(self, client):
+        with patch("routers.password.send_reset") as mock_reset:
+            res = client.post("/api/auth/forgot-password", json={"email": "ghost@test.mx"})
+        assert res.status_code == 200
+        assert res.json()["message"] == "Si el email existe, recibirás instrucciones en breve."
+        mock_reset.assert_not_called()
+
+    def test_forgot_pending_user_200_no_token(self, client, admin_headers):
+        _create_pending_user(client, admin_headers, "forgotpending@test.mx")
+        with patch("routers.password.send_reset") as mock_reset:
+            res = client.post("/api/auth/forgot-password", json={"email": "forgotpending@test.mx"})
+        assert res.status_code == 200
+        mock_reset.assert_not_called()
+
+    def test_reset_valid_token_200_activo_unchanged(self, client, capturista_user, _test_db_conn):
+        with patch("routers.password.send_reset") as mock_reset:
+            client.post("/api/auth/forgot-password", json={"email": "cap@test.mx"})
+        raw = mock_reset.call_args.args[1]
+        res = client.post("/api/auth/reset-password", json={"token": raw, "password": "resetpass123"})
+        assert res.status_code == 200
+        # New password works; activo unchanged (still active).
+        login = client.post("/api/auth/login", json={"email": "cap@test.mx", "password": "resetpass123"})
+        assert login.status_code == 200
+        assert _token_used_at(_test_db_conn, raw) is not None
+
+    def test_reset_expired_token_400(self, client, capturista_user, _test_db_conn):
+        raw = "expired-reset-token"
+        _insert_token(_test_db_conn, capturista_user["id"], raw, "reset", "-1 hour")
+        res = client.post("/api/auth/reset-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+
+    def test_reset_wrong_tipo_400(self, client, capturista_user, _test_db_conn):
+        """An invite token must not redeem on the reset path."""
+        raw = "invite-token-on-reset-path"
+        _insert_token(_test_db_conn, capturista_user["id"], raw, "invite", "72 hours")
+        res = client.post("/api/auth/reset-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+
+    def test_reset_already_used_400(self, client, capturista_user, _test_db_conn):
+        raw = "used-reset-token"
+        _insert_token(_test_db_conn, capturista_user["id"], raw, "reset", "1 hour", used=True)
+        res = client.post("/api/auth/reset-password", json={"token": raw, "password": "whatever123"})
+        assert res.status_code == 400
+
+    def test_reset_token_invalidated_on_reissue(self, client, capturista_user, _test_db_conn):
+        """Requesting a second reset invalidates the first token."""
+        with patch("routers.password.send_reset") as m1:
+            client.post("/api/auth/forgot-password", json={"email": "cap@test.mx"})
+        first_raw = m1.call_args.args[1]
+        with patch("routers.password.send_reset") as m2:
+            client.post("/api/auth/forgot-password", json={"email": "cap@test.mx"})
+        second_raw = m2.call_args.args[1]
+
+        # First token now rejected.
+        res_first = client.post("/api/auth/reset-password", json={"token": first_raw, "password": "firstpass123"})
+        assert res_first.status_code == 400
+        # Second token works.
+        res_second = client.post("/api/auth/reset-password", json={"token": second_raw, "password": "secondpass123"})
+        assert res_second.status_code == 200
+
+    def test_reset_password_too_short_422(self, client, capturista_user, _test_db_conn):
+        raw = "reset-short-token"
+        _insert_token(_test_db_conn, capturista_user["id"], raw, "reset", "1 hour")
+        res = client.post("/api/auth/reset-password", json={"token": raw, "password": "short"})
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Change password (authenticated)
+# ---------------------------------------------------------------------------
+
+class TestChangePassword:
+    def test_correct_current_204(self, client, capturista_headers):
+        res = client.post("/api/me/password", json={
+            "current_password": "cappass123",
+            "new_password": "changedpass123",
+        }, headers=capturista_headers)
+        assert res.status_code == 204
+        # New password works for login.
+        login = client.post("/api/auth/login", json={"email": "cap@test.mx", "password": "changedpass123"})
+        assert login.status_code == 200
+
+    def test_wrong_current_400(self, client, capturista_headers):
+        res = client.post("/api/me/password", json={
+            "current_password": "wrongpassword",
+            "new_password": "changedpass123",
+        }, headers=capturista_headers)
+        assert res.status_code == 400
+
+    def test_new_too_short_422(self, client, capturista_headers):
+        res = client.post("/api/me/password", json={
+            "current_password": "cappass123",
+            "new_password": "short",
+        }, headers=capturista_headers)
+        assert res.status_code == 422
+
+    def test_unauthenticated_401(self, client):
+        res = client.post("/api/me/password", json={
+            "current_password": "x", "new_password": "changedpass123",
+        })
+        assert res.status_code == 401
+
+    @pytest.mark.parametrize("hdr_fixture,email,current_pw", [
+        ("admin_headers", "admin@test.mx", "adminpass123"),
+        ("capturista_headers", "cap@test.mx", "cappass123"),
+        ("tecnico_headers", "tec@test.mx", "tecpass123"),
+        ("organizacion_headers", "org@test.mx", "orgpass123"),
+    ])
+    def test_all_four_roles(self, client, request, hdr_fixture, email, current_pw):
+        headers = request.getfixturevalue(hdr_fixture)
+        res = client.post("/api/me/password", json={
+            "current_password": current_pw,
+            "new_password": "newrolepass123",
+        }, headers=headers)
+        assert res.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# _verify_password hardening
+# ---------------------------------------------------------------------------
+
+class TestVerifyPasswordHardening:
+    def test_none_hash_returns_false(self):
+        assert _verify_password("anything", None) is False
+
+    def test_empty_string_hash_returns_false(self):
+        assert _verify_password("anything", "") is False

--- a/backend/tests/test_usuarios.py
+++ b/backend/tests/test_usuarios.py
@@ -5,6 +5,8 @@ TDD: Tests written BEFORE the implementation.
 Spec reference: user-management specification (fase-1-fundacion).
 """
 
+from unittest.mock import patch
+
 import pytest
 
 
@@ -91,6 +93,109 @@ class TestCreateUser:
         }, headers=admin_headers)
 
         assert res.status_code == 422
+
+
+class TestInviteOnCreate:
+    """POST /api/usuarios without a password → passwordless (Pendiente) account."""
+
+    def test_create_user_without_password_creates_pending_201(self, client, admin_headers):
+        """No password → 201, activo=False, pending=True, invite email sent."""
+        with patch("routers.usuarios.send_invite") as mock_invite:
+            res = client.post("/api/usuarios", json={
+                "nombre": "Invitado Uno",
+                "email": "invite1@test.mx",
+                "rol": "capturista",
+            }, headers=admin_headers)
+
+        assert res.status_code == 201
+        data = res.json()
+        assert data["activo"] is False
+        assert data["pending"] is True
+        mock_invite.assert_called_once()
+        # send_invite(to_email, raw_token) — raw token must be a non-empty string.
+        args, _ = mock_invite.call_args
+        assert args[0] == "invite1@test.mx"
+        assert isinstance(args[1], str) and len(args[1]) > 0
+
+    def test_create_user_without_password_sets_hash_null(self, client, admin_headers, _test_db_conn):
+        """The passwordless account row has password_hash IS NULL in the DB."""
+        with patch("routers.usuarios.send_invite"):
+            res = client.post("/api/usuarios", json={
+                "nombre": "Invitado Dos",
+                "email": "invite2@test.mx",
+                "rol": "tecnico",
+            }, headers=admin_headers)
+        uid = res.json()["usuario_id"]
+
+        import psycopg2.extras
+        with _test_db_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute("SELECT password_hash, activo FROM usuarios WHERE id = %s", (uid,))
+            row = cur.fetchone()
+        _test_db_conn.commit()
+        assert row["password_hash"] is None
+        assert row["activo"] is False
+
+    def test_create_user_without_password_issues_invite_token(self, client, admin_headers, _test_db_conn):
+        """A single invite token (tipo='invite', unused) is stored for the user."""
+        with patch("routers.usuarios.send_invite"):
+            res = client.post("/api/usuarios", json={
+                "nombre": "Invitado Tres",
+                "email": "invite3@test.mx",
+                "rol": "capturista",
+            }, headers=admin_headers)
+        uid = res.json()["usuario_id"]
+
+        import psycopg2.extras
+        with _test_db_conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT tipo, used_at FROM password_tokens WHERE usuario_id = %s", (uid,)
+            )
+            tokens = cur.fetchall()
+        _test_db_conn.commit()
+        assert len(tokens) == 1
+        assert tokens[0]["tipo"] == "invite"
+        assert tokens[0]["used_at"] is None
+
+    def test_create_user_email_failure_still_201_pending(self, client, admin_headers):
+        """Fail-open: EmailDeliveryError does not roll back the user (still 201)."""
+        from utils.email import EmailDeliveryError
+        with patch("routers.usuarios.send_invite", side_effect=EmailDeliveryError("down")):
+            res = client.post("/api/usuarios", json={
+                "nombre": "Invitado Cuatro",
+                "email": "invite4@test.mx",
+                "rol": "tecnico",
+            }, headers=admin_headers)
+        assert res.status_code == 201
+        assert res.json()["pending"] is True
+
+    def test_create_user_with_password_not_pending(self, client, admin_headers):
+        """Legacy path (password provided) stays active and not pending."""
+        res = client.post("/api/usuarios", json={
+            "nombre": "Con Password",
+            "email": "withpass@test.mx",
+            "password": "password123",
+            "rol": "capturista",
+        }, headers=admin_headers)
+        assert res.status_code == 201
+        data = res.json()
+        assert data["activo"] is True
+        assert data["pending"] is False
+
+    def test_list_usuarios_includes_pending_badge(self, client, admin_headers):
+        """GET /usuarios exposes pending=True for a passwordless account."""
+        with patch("routers.usuarios.send_invite"):
+            client.post("/api/usuarios", json={
+                "nombre": "Invitado Lista",
+                "email": "invitelist@test.mx",
+                "rol": "capturista",
+            }, headers=admin_headers)
+
+        res = client.get("/api/usuarios", headers=admin_headers)
+        assert res.status_code == 200
+        users = res.json()
+        pend = next(u for u in users if u["email"] == "invitelist@test.mx")
+        assert pend["pending"] is True
+        assert pend["activo"] is False
 
 
 class TestListUsers:

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -1,0 +1,92 @@
+"""
+Email delivery via the Resend REST API.
+
+Environment variables:
+  RESEND_API_KEY   — Bearer token for https://api.resend.com (required to send).
+  EMAIL_FROM       — Sender address (default "onboarding@resend.dev" for dev).
+  APP_BASE_URL     — Base URL used to build activation/reset links in emails
+                     (e.g. "https://sillas.example.com"). If unset the links are
+                     relative ("/set-password.html?token=..."); production MUST
+                     set this so email clients resolve absolute URLs.
+
+All copy is in Spanish (neutral/professional) — the platform is Spanish.
+
+Design note: callers treat email delivery as best-effort (fail-open). They
+catch EmailDeliveryError, log a warning, and keep the created user/token so an
+admin can resend the invitation. Raw tokens appear only in the link and are
+never logged or persisted (only their sha256 hash is stored).
+"""
+
+import os
+
+import httpx
+
+_RESEND_ENDPOINT = "https://api.resend.com/emails"
+_TIMEOUT_SECONDS = 10.0
+_DEFAULT_FROM = "onboarding@resend.dev"
+
+
+class EmailDeliveryError(Exception):
+    """Raised when Resend returns a non-2xx status or the request times out."""
+
+
+def _resend_post(to: str, subject: str, html: str) -> None:
+    """POST a single email to Resend. Raises EmailDeliveryError on failure."""
+    api_key = os.environ["RESEND_API_KEY"]
+    from_addr = os.environ.get("EMAIL_FROM", _DEFAULT_FROM)
+    try:
+        resp = httpx.post(
+            _RESEND_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "from": from_addr,
+                "to": [to],
+                "subject": subject,
+                "html": html,
+            },
+            timeout=_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+    except httpx.TimeoutException as exc:
+        raise EmailDeliveryError("Resend request timed out") from exc
+    except httpx.HTTPStatusError as exc:
+        raise EmailDeliveryError(
+            f"Resend returned {exc.response.status_code}"
+        ) from exc
+    except httpx.HTTPError as exc:  # transport/connection errors
+        raise EmailDeliveryError(f"Resend request failed: {exc}") from exc
+
+
+def _base_url() -> str:
+    """Return APP_BASE_URL without a trailing slash (empty when unset)."""
+    return os.environ.get("APP_BASE_URL", "").rstrip("/")
+
+
+def send_invite(to_email: str, raw_token: str) -> None:
+    """Send the account-activation (invite) email. Valid for 72 hours."""
+    link = f"{_base_url()}/set-password.html?token={raw_token}"
+    html = f"""
+    <p>Tu cuenta en <strong>Ecosistema VIDA UG</strong> ha sido creada.</p>
+    <p>Hacé clic en el siguiente enlace para establecer tu contraseña y activar
+    tu cuenta (este enlace expira en 72 horas):</p>
+    <p><a href="{link}">Activar mi cuenta</a></p>
+    <p>Si no esperabas este mensaje, podés ignorarlo.</p>
+    """
+    _resend_post(to_email, "Bienvenido/a — Activá tu cuenta", html)
+
+
+def send_reset(to_email: str, raw_token: str) -> None:
+    """Send the password-reset email. Valid for 1 hour."""
+    link = f"{_base_url()}/reset-password.html?token={raw_token}"
+    html = f"""
+    <p>Recibimos una solicitud para restablecer la contraseña de tu cuenta en
+    <strong>Ecosistema VIDA UG</strong>.</p>
+    <p>Hacé clic en el siguiente enlace para crear una nueva contraseña
+    (este enlace expira en 1 hora):</p>
+    <p><a href="{link}">Restablecer mi contraseña</a></p>
+    <p>Si no solicitaste este cambio, podés ignorarlo.</p>
+    """
+    _resend_post(to_email, "Recuperación de contraseña", html)

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -65,10 +65,11 @@ def _base_url() -> str:
     return os.environ.get("APP_BASE_URL", "").rstrip("/")
 
 
-def send_invite(to_email: str, raw_token: str) -> None:
+def send_invite(to_email: str, raw_token: str, nombre: str) -> None:
     """Send the account-activation (invite) email. Valid for 72 hours."""
     link = f"{_base_url()}/set-password.html?token={raw_token}"
     html = f"""
+    <p>Hola {nombre}:</p>
     <p>Tu cuenta en <strong>Ecosistema VIDA UG</strong> ha sido creada.</p>
     <p>Hacé clic en el siguiente enlace para establecer tu contraseña y activar
     tu cuenta (este enlace expira en 72 horas):</p>

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -53,16 +53,20 @@ def _resend_post(to: str, subject: str, html: str) -> None:
     except httpx.TimeoutException as exc:
         raise EmailDeliveryError("Resend request timed out") from exc
     except httpx.HTTPStatusError as exc:
-        raise EmailDeliveryError(
-            f"Resend returned {exc.response.status_code}"
-        ) from exc
+        raise EmailDeliveryError(f"Resend returned {exc.response.status_code}") from exc
     except httpx.HTTPError as exc:  # transport/connection errors
         raise EmailDeliveryError(f"Resend request failed: {exc}") from exc
 
 
 def _base_url() -> str:
-    """Return APP_BASE_URL without a trailing slash (empty when unset)."""
-    return os.environ.get("APP_BASE_URL", "").rstrip("/")
+    """Return APP_BASE_URL without a trailing slash. Falls back to the
+    Vercel-injected deployment URL so preview deployments build working
+    email links without per-branch configuration."""
+    explicit = os.environ.get("APP_BASE_URL", "").rstrip("/")
+    if explicit:
+        return explicit
+    vercel_url = os.environ.get("VERCEL_URL", "")
+    return f"https://{vercel_url}" if vercel_url else ""
 
 
 def send_invite(to_email: str, raw_token: str, nombre: str) -> None:
@@ -70,13 +74,13 @@ def send_invite(to_email: str, raw_token: str, nombre: str) -> None:
     link = f"{_base_url()}/set-password.html?token={raw_token}"
     html = f"""
     <p>Hola {nombre}:</p>
-    <p>Tu cuenta en <strong>Ecosistema VIDA UG</strong> ha sido creada.</p>
-    <p>Hacé clic en el siguiente enlace para establecer tu contraseña y activar
+    <p>Tu cuenta en <strong>200 SILLAS 200 CAMPEONES</strong> ha sido creada.</p>
+    <p>Haz clic en el siguiente enlace para establecer tu contraseña y activar
     tu cuenta (este enlace expira en 72 horas):</p>
     <p><a href="{link}">Activar mi cuenta</a></p>
-    <p>Si no esperabas este mensaje, podés ignorarlo.</p>
+    <p>Si no esperabas este mensaje, puedes ignorarlo.</p>
     """
-    _resend_post(to_email, "Bienvenido/a — Activá tu cuenta", html)
+    _resend_post(to_email, "Bienvenido/a — Activa tu cuenta", html)
 
 
 def send_reset(to_email: str, raw_token: str) -> None:
@@ -84,10 +88,10 @@ def send_reset(to_email: str, raw_token: str) -> None:
     link = f"{_base_url()}/reset-password.html?token={raw_token}"
     html = f"""
     <p>Recibimos una solicitud para restablecer la contraseña de tu cuenta en
-    <strong>Ecosistema VIDA UG</strong>.</p>
-    <p>Hacé clic en el siguiente enlace para crear una nueva contraseña
+    <strong>200 SILLAS 200 CAMPEONES</strong>.</p>
+    <p>Haz clic en el siguiente enlace para crear una nueva contraseña
     (este enlace expira en 1 hora):</p>
     <p><a href="{link}">Restablecer mi contraseña</a></p>
-    <p>Si no solicitaste este cambio, podés ignorarlo.</p>
+    <p>Si no solicitaste este cambio, puedes ignorarlo.</p>
     """
     _resend_post(to_email, "Recuperación de contraseña", html)

--- a/backend/utils/tokens.py
+++ b/backend/utils/tokens.py
@@ -1,0 +1,31 @@
+"""
+Shared token mechanics for the password_tokens flows (invite + reset).
+
+Kept in utils/ so both usuarios.py (invite-on-create) and the password router
+generate and hash tokens identically — no drift.
+
+Security properties:
+  - Generation: secrets.token_urlsafe(32) → 256 bits of URL-safe entropy.
+  - Storage: only the sha256 hex of the raw token is persisted (token_hash).
+    The raw token travels only in the email link and is never logged/stored.
+  - Expiry is applied in SQL (NOW() + INTERVAL) using the TTL constants below,
+    so the database clock is the single source of truth.
+"""
+
+import hashlib
+import secrets
+
+# TTLs live here as SQL INTERVAL literals so callers interpolate them directly
+# into `expires_at = NOW() + INTERVAL '...'` (never from user input).
+INVITE_TTL_SQL = "72 hours"
+RESET_TTL_SQL = "1 hour"
+
+
+def generate_raw_token() -> str:
+    """Return a fresh URL-safe raw token (never stored — only its hash is)."""
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(raw_token: str) -> str:
+    """Return the sha256 hex digest stored in password_tokens.token_hash."""
+    return hashlib.sha256(raw_token.encode()).hexdigest()

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -239,27 +239,6 @@
             <div class="space-y-2">
               <label
                 class="block text-xs font-semibold text-slate-600"
-                for="password"
-                >Contraseña</label
-              >
-              <div class="relative">
-                <span
-                  class="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 text-lg pointer-events-none"
-                  >lock</span
-                >
-                <input
-                  id="password"
-                  name="password"
-                  type="password"
-                  placeholder="Mínimo 8 caracteres"
-                  class="w-full pl-11 pr-4 py-3 text-sm"
-                />
-              </div>
-            </div>
-
-            <div class="space-y-2">
-              <label
-                class="block text-xs font-semibold text-slate-600"
                 for="rol"
                 >Rol</label
               >
@@ -627,9 +606,17 @@
           </td>
           <td class="px-6 py-3.5 text-sm text-slate-500 hidden md:table-cell">${_esc(u.email)}</td>
           <td class="px-6 py-3.5">${_rolBadge(u.rol)}</td>
-          <td class="px-6 py-3.5">${_estadoBadge(u.activo)}</td>
+          <td class="px-6 py-3.5">${_estadoBadge(u.activo, u.pending)}</td>
           <td class="px-6 py-3.5 text-right">
             <div class="flex items-center justify-end gap-1">
+              ${u.pending
+                ? `<button onclick="reenviarInvitacion(${u.usuario_id})"
+                  class="btn-icon hover:bg-orange-50 hover:text-ug-orange-pure hover:border-orange-200"
+                  title="Reenviar invitación" aria-label="Reenviar invitación">
+                  <span class="material-symbols-outlined" aria-hidden="true">forward_to_inbox</span>
+                </button>`
+                : ''
+              }
               ${u.rol === 'organizacion' && u.activo
                 ? `<button onclick="gestionarOrganizacion(${u.usuario_id})"
                   class="btn-icon hover:bg-purple-50 hover:text-primary hover:border-primary/30"
@@ -694,6 +681,24 @@
           alert("No se pudo desactivar el usuario. Intente de nuevo.");
         }
       }
+
+      // ── Resend invitation (Pendiente users) ──────────────────────────────────────
+      window.reenviarInvitacion = async function (id) {
+        if (!confirm("¿Reenviar el email de invitación a este usuario?")) return;
+        try {
+          const res = await _authFetch(`/usuarios/${id}/reenviar-invitacion`, {
+            method: "POST",
+          });
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            alert(data.detail || "No se pudo reenviar la invitación.");
+            return;
+          }
+          await loadUsuarios();
+        } catch (_) {
+          alert("No se pudo conectar con el servidor.");
+        }
+      };
 
       // ── Reactivate user ─────────────────────────────────────────────────────────
       async function reactivateUsuario(id) {
@@ -1108,18 +1113,13 @@
 
           const nombre = document.getElementById("nombre").value.trim();
           const email = document.getElementById("email").value.trim();
-          const password = document.getElementById("password").value;
           const rol = document.getElementById("rol").value;
 
-          if (!nombre || !email || !password || !rol) {
+          if (!nombre || !email || !rol) {
             _show(
               errorEl,
               "Complete todos los campos antes de crear el usuario.",
             );
-            return;
-          }
-          if (password.length < 8) {
-            _show(errorEl, "La contraseña debe tener al menos 8 caracteres.");
             return;
           }
 
@@ -1130,7 +1130,7 @@
             const res = await _authFetch("/usuarios", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ nombre, email, password, rol }),
+              body: JSON.stringify({ nombre, email, rol }),
             });
             const data = await res.json().catch(() => ({}));
 
@@ -1141,7 +1141,7 @@
 
             _show(
               successEl,
-              `Usuario "${data.nombre}" creado correctamente con rol "${data.rol}".`,
+              `Usuario "${data.nombre}" creado. Se envió un email de invitación a ${email}.`,
             );
             e.target.reset();
             await loadUsuarios();
@@ -1176,7 +1176,10 @@
     </span>`;
       }
 
-      function _estadoBadge(activo) {
+      function _estadoBadge(activo, pending) {
+        if (pending) {
+          return '<span class="badge badge--warning"><span class="material-symbols-outlined">email</span>Pendiente</span>';
+        }
         return activo
           ? '<span class="badge badge--success"><span class="material-symbols-outlined">check_circle</span>Activo</span>'
           : '<span class="badge badge--neutral">Inactivo</span>';

--- a/front/Admin-view/admin-usuarios.html
+++ b/front/Admin-view/admin-usuarios.html
@@ -38,6 +38,7 @@
     <script src="../assets/js/delight.js"></script>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/apiClient.js"></script>
+    <script src="../assets/js/change-password.js"></script>
     <script src="../assets/js/confirmation-modal.js?v=2"></script>
     <script src="../assets/js/mascot.js?v=2"></script>
     <link href="../assets/css/admin-usuarios.css" rel="stylesheet" />
@@ -103,6 +104,13 @@
             </p>
             <p class="text-slate-400 text-[10px]">Administrador</p>
           </div>
+          <button
+            id="btn-cambiar-pwd"
+            title="Cambiar contraseña"
+            class="text-slate-400 hover:text-ug-orange-pure transition-colors"
+          >
+            <span class="material-symbols-outlined text-lg">lock_reset</span>
+          </button>
           <button
             id="btn-logout"
             title="Cerrar sesión"
@@ -425,6 +433,21 @@
           </div>
         </div>
 
+        <!-- ── Change Password Modal ── -->
+        <div id="change-pwd-modal" class="hidden fixed inset-0 z-50" style="background:rgba(43,6,61,0.6);backdrop-filter:blur(3px);">
+          <div class="flex items-center justify-center min-h-screen p-4">
+            <div class="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 space-y-5">
+              <div class="flex items-center justify-between">
+                <h3 class="text-lg font-bold text-slate-900">Cambiar contraseña</h3>
+                <button id="btn-cerrar-change-pwd" class="w-8 h-8 rounded-lg hover:bg-slate-100 flex items-center justify-center text-slate-400">
+                  <span class="material-symbols-outlined text-xl">close</span>
+                </button>
+              </div>
+              <div id="change-password-section"></div>
+            </div>
+          </div>
+        </div>
+
         <!-- ── Manage Org Modal ── -->
         <div id="manage-org-modal" class="hidden fixed inset-0 z-50" style="background:rgba(43,6,61,0.6);backdrop-filter:blur(3px);">
           <div class="flex items-center justify-center min-h-screen p-4">
@@ -555,6 +578,23 @@
       document
         .getElementById("btn-logout-mobile")
         .addEventListener("click", _logout);
+
+      // ── Change password (admin, own account) ────────────────────────────────────
+      let _changePwdInit = false;
+      document.getElementById("btn-cambiar-pwd").addEventListener("click", function () {
+        if (!_changePwdInit) {
+          ChangePassword.init({
+            containerId: "change-password-section",
+            apiPath: "/me/password",
+            authFetchFn: SessionGuard.authFetch,
+          });
+          _changePwdInit = true;
+        }
+        document.getElementById("change-pwd-modal").classList.remove("hidden");
+      });
+      document.getElementById("btn-cerrar-change-pwd").addEventListener("click", function () {
+        document.getElementById("change-pwd-modal").classList.add("hidden");
+      });
       document
         .getElementById("btn-refresh")
         .addEventListener("click", loadUsuarios);

--- a/front/Capturista-view/perfil-capturista.html
+++ b/front/Capturista-view/perfil-capturista.html
@@ -29,6 +29,7 @@
 <link href="../assets/css/theme.css" rel="stylesheet"/>
 <script src="../assets/js/session-guard.js"></script>
 <script src="../assets/js/apiClient.js"></script>
+<script src="../assets/js/change-password.js"></script>
 <script src="../assets/js/confirmation-modal.js?v=2"></script>
 <script src="../assets/js/mascot.js?v=2"></script>
 <script src="../assets/js/theme-toggle.js"></script>
@@ -254,6 +255,15 @@
         </div>
       </div>
     </section>
+
+    <!-- Change password -->
+    <section class="card rise rise-4 overflow-hidden">
+      <div class="px-6 py-4 sm:px-8 border-b border-slate-100 flex items-center gap-2.5">
+        <span class="material-symbols-outlined text-ug-orange-pure text-xl">lock_reset</span>
+        <h2 class="text-base font-bold" style="color: var(--c-title);">Cambiar contraseña</h2>
+      </div>
+      <div id="change-password-section" class="px-6 py-5 sm:px-8"></div>
+    </section>
   </div>
 </main>
 
@@ -318,6 +328,9 @@
 <script>
   // ── Auth guard ──────────────────────────────────────────────────────────────
   SessionGuard.requireRole(['capturista'], '../login.html');
+
+  // Shared change-password form.
+  ChangePassword.init({ containerId: 'change-password-section', apiPath: '/me/password', authFetchFn: SessionGuard.authFetch });
   const session = SessionGuard.getSession();
 
   // Populate user info

--- a/front/Tecnico-view/vista_tecnicos.html
+++ b/front/Tecnico-view/vista_tecnicos.html
@@ -37,6 +37,7 @@
 <script src="../assets/js/delight.js"></script>
     <script src="../assets/js/session-guard.js"></script>
     <script src="../assets/js/apiClient.js"></script>
+    <script src="../assets/js/change-password.js"></script>
     <script src="../assets/js/confirmation-modal.js?v=2"></script>
     <script src="../assets/js/mascot.js?v=2"></script>
     <link href="../assets/css/vista-tecnicos.css" rel="stylesheet" />
@@ -444,6 +445,15 @@
           <span class="material-symbols-outlined text-base">chevron_right</span>
         </button>
       </div>
+
+      <!-- Change password -->
+      <section class="bg-white border border-slate-200 rounded-2xl overflow-hidden mt-6">
+        <div class="px-6 py-4 border-b border-slate-100 flex items-center gap-2.5">
+          <span class="material-symbols-outlined text-xl text-ug-orange-pure">lock_reset</span>
+          <h2 class="text-base font-bold text-slate-800">Cambiar contraseña</h2>
+        </div>
+        <div id="change-password-section" class="px-6 py-5"></div>
+      </section>
     </main>
 
     <!-- ── Detail Modal ────────────────────────────────────────────────────── -->
@@ -675,6 +685,9 @@
       (function boot() {
         // Role guard: tecnico only.
         SessionGuard.requireRole(["tecnico"], "../login.html");
+
+        // Shared change-password form.
+        ChangePassword.init({ containerId: "change-password-section", apiPath: "/me/password", authFetchFn: SessionGuard.authFetch });
 
         const session = SessionGuard.getSession();
         $("user-nombre").textContent = session.nombre || "—";

--- a/front/assets/js/change-password.js
+++ b/front/assets/js/change-password.js
@@ -1,0 +1,120 @@
+/* change-password.js — Shared "change my password" form for Ecosistema VIDA UG.
+
+   Self-contained IIFE (plain global — no ES modules, consistent with
+   session-guard.js / apiClient.js). Renders a small form into a container and
+   POSTs { current_password, new_password } to the authenticated endpoint.
+
+   Usage (after loading apiClient.js, and session-guard.js on protected pages):
+
+     ChangePassword.init({
+       containerId: 'change-password-section', // <div> to inject into
+       apiPath:     '/me/password',             // default '/me/password'
+       authFetchFn: SessionGuard.authFetch,     // optional; defaults to ApiClient
+     });
+
+   Shared across the 4 role profiles so the change-password UI never drifts. */
+(function () {
+  "use strict";
+
+  function _esc(str) {
+    return String(str == null ? "" : str)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  // Post the payload. When an authFetchFn is provided (e.g. SessionGuard.authFetch),
+  // build the absolute URL via ApiClient; otherwise use ApiClient.post which
+  // already attaches the Bearer token.
+  function _post(apiPath, payload, authFetchFn) {
+    if (typeof authFetchFn === "function") {
+      return authFetchFn(ApiClient.url(apiPath), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    }
+    return ApiClient.post(apiPath, { json: payload });
+  }
+
+  function init(opts) {
+    opts = opts || {};
+    var container = document.getElementById(opts.containerId);
+    if (!container) return; // page did not provide the mount point
+    var apiPath = opts.apiPath || "/me/password";
+    var authFetchFn = opts.authFetchFn;
+
+    container.innerHTML = [
+      '<form class="space-y-4" novalidate>',
+      '  <div class="space-y-1.5">',
+      '    <label class="block text-xs font-semibold text-slate-600" for="cp-current">Contraseña actual</label>',
+      '    <input id="cp-current" type="password" autocomplete="current-password" placeholder="Tu contraseña actual" class="w-full px-4 py-3 text-sm"/>',
+      '  </div>',
+      '  <div class="space-y-1.5">',
+      '    <label class="block text-xs font-semibold text-slate-600" for="cp-new">Nueva contraseña</label>',
+      '    <input id="cp-new" type="password" autocomplete="new-password" placeholder="Mínimo 8 caracteres" class="w-full px-4 py-3 text-sm"/>',
+      '  </div>',
+      '  <div class="space-y-1.5">',
+      '    <label class="block text-xs font-semibold text-slate-600" for="cp-confirm">Confirmar nueva contraseña</label>',
+      '    <input id="cp-confirm" type="password" autocomplete="new-password" placeholder="Repetí la nueva contraseña" class="w-full px-4 py-3 text-sm"/>',
+      '  </div>',
+      '  <p id="cp-error" class="hidden text-red-600 text-sm bg-red-50 border border-red-200 rounded-lg px-4 py-2.5" role="alert"></p>',
+      '  <p id="cp-success" class="hidden text-green-700 text-sm bg-green-50 border border-green-200 rounded-lg px-4 py-2.5" role="status"></p>',
+      '  <button id="cp-submit" type="submit" class="btn-primary w-full sm:w-auto px-6 py-3 text-sm rounded-xl flex items-center justify-center gap-2 disabled:opacity-60">',
+      '    <span class="material-symbols-outlined text-lg">lock_reset</span>',
+      '    <span id="cp-submit-text">Cambiar contraseña</span>',
+      '  </button>',
+      '</form>',
+    ].join("");
+
+    var form = container.querySelector("form");
+    var errorEl = container.querySelector("#cp-error");
+    var successEl = container.querySelector("#cp-success");
+
+    function showError(msg) {
+      successEl.classList.add("hidden");
+      errorEl.textContent = msg;
+      errorEl.classList.remove("hidden");
+    }
+    function showSuccess(msg) {
+      errorEl.classList.add("hidden");
+      successEl.textContent = msg;
+      successEl.classList.remove("hidden");
+    }
+
+    form.addEventListener("submit", async function (e) {
+      e.preventDefault();
+      errorEl.classList.add("hidden");
+      successEl.classList.add("hidden");
+
+      var current = container.querySelector("#cp-current").value;
+      var next = container.querySelector("#cp-new").value;
+      var confirm = container.querySelector("#cp-confirm").value;
+
+      if (!current) { showError("Ingresá tu contraseña actual."); return; }
+      if (next.length < 8) { showError("La nueva contraseña debe tener al menos 8 caracteres."); return; }
+      if (next !== confirm) { showError("Las contraseñas no coinciden."); return; }
+
+      var btn = container.querySelector("#cp-submit");
+      var btnText = container.querySelector("#cp-submit-text");
+      btn.disabled = true;
+      btnText.textContent = "Guardando…";
+
+      try {
+        var res = await _post(apiPath, { current_password: current, new_password: next }, authFetchFn);
+        if (res.status === 204 || res.ok) {
+          form.reset();
+          showSuccess("Contraseña actualizada.");
+        } else {
+          var data = await res.json().catch(function () { return {}; });
+          showError(_esc(data.detail) || "No se pudo cambiar la contraseña.");
+        }
+      } catch (_) {
+        showError("No se pudo conectar con el servidor.");
+      } finally {
+        btn.disabled = false;
+        btnText.textContent = "Cambiar contraseña";
+      }
+    });
+  }
+
+  window.ChangePassword = { init: init };
+})();

--- a/front/forgot-password.html
+++ b/front/forgot-password.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Recuperar contraseña | Ecosistema VIDA UG</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet"/>
+<script id="tailwind-config">
+  tailwind.config = {
+    darkMode: "class",
+    theme: { extend: {
+      colors: {
+        "primary": "#2B063D", "primary-bold": "#3A0A4F",
+        "ug-orange": "#F15A24", "ug-orange-hover": "#E84B10",
+        "ug-orange-pure": "#FF5A1F", "warm-bg": "#FBF7F5",
+      },
+      fontFamily: { "display": ["Public Sans"] },
+      borderRadius: { "DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "2xl": "1rem", "full": "9999px" },
+    } },
+  }
+</script>
+<link href="assets/css/theme.css" rel="stylesheet"/>
+<script src="assets/js/apiClient.js"></script>
+<script src="assets/js/theme-toggle.js"></script>
+</head>
+<body class="font-display min-h-screen flex flex-col items-center justify-center bg-warm-bg px-4 py-10">
+
+<main class="w-full max-w-md">
+  <div class="bg-white rounded-2xl shadow-xl border border-slate-100 p-7 sm:p-9">
+
+    <div class="flex flex-col items-center text-center mb-6">
+      <div class="w-14 h-14 rounded-2xl bg-orange-50 border border-orange-100 flex items-center justify-center mb-3">
+        <span class="material-symbols-outlined text-3xl text-ug-orange-pure">mail_lock</span>
+      </div>
+      <h1 class="text-xl font-extrabold tracking-tight text-primary">Recuperar contraseña</h1>
+      <p class="text-slate-500 text-sm mt-1">Ingresá tu correo y te enviaremos un enlace para restablecerla.</p>
+    </div>
+
+    <!-- Form -->
+    <form id="form-forgot" class="space-y-4" novalidate>
+      <div class="space-y-1.5">
+        <label class="block text-xs font-semibold text-slate-600" for="email">Correo electrónico</label>
+        <div class="relative">
+          <span class="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 text-lg pointer-events-none">mail</span>
+          <input id="email" name="email" type="email" autocomplete="email"
+            placeholder="usuario@ejemplo.com" class="w-full pl-11 pr-4 py-3 text-sm"/>
+        </div>
+      </div>
+
+      <button id="btn-submit" type="submit" class="btn-primary w-full py-3 text-sm rounded-xl flex items-center justify-center gap-2 disabled:opacity-60">
+        <span class="material-symbols-outlined text-lg">send</span>
+        <span id="btn-text">Enviar enlace</span>
+      </button>
+    </form>
+
+    <!-- Result (enumeration-safe: always the same message) -->
+    <div id="result-box" class="hidden text-center space-y-4">
+      <div class="w-14 h-14 rounded-2xl bg-green-50 border border-green-100 flex items-center justify-center mx-auto">
+        <span class="material-symbols-outlined text-3xl text-green-600">mark_email_read</span>
+      </div>
+      <p class="text-slate-700 text-sm font-semibold">Si el email existe en el sistema, recibirás un enlace en breve.</p>
+      <a href="login.html" class="inline-flex items-center justify-center gap-1.5 text-sm font-semibold text-primary-bold hover:text-ug-orange-pure transition-colors">
+        <span class="material-symbols-outlined text-base">arrow_back</span>
+        Volver al inicio de sesión
+      </a>
+    </div>
+
+    <div class="mt-5 text-center">
+      <a href="login.html" id="back-link" class="inline-flex items-center gap-1.5 text-xs font-semibold text-slate-500 hover:text-ug-orange-pure transition-colors">
+        <span class="material-symbols-outlined text-sm">arrow_back</span>
+        Volver al inicio de sesión
+      </a>
+    </div>
+  </div>
+</main>
+
+<script>
+  (function () {
+    "use strict";
+    var form = document.getElementById("form-forgot");
+
+    form.addEventListener("submit", async function (e) {
+      e.preventDefault();
+      var email = document.getElementById("email").value.trim();
+      if (!email) return;
+
+      var btn = document.getElementById("btn-submit");
+      var btnText = document.getElementById("btn-text");
+      btn.disabled = true;
+      btnText.textContent = "Enviando…";
+
+      try {
+        // Enumeration-safe: the backend always returns 200 with a generic
+        // message, so we surface the same result regardless of the outcome.
+        await ApiClient.fetch("/auth/forgot-password", {
+          method: "POST", auth: false, json: { email: email },
+        });
+      } catch (_) {
+        /* Even on a network error we show the generic message to avoid
+           leaking whether the email exists. */
+      } finally {
+        form.classList.add("hidden");
+        document.getElementById("back-link").classList.add("hidden");
+        document.getElementById("result-box").classList.remove("hidden");
+      }
+    });
+  })();
+</script>
+</body>
+</html>

--- a/front/login.html
+++ b/front/login.html
@@ -173,6 +173,9 @@
               <span class="material-symbols-outlined text-xl" id="toggle-pwd-icon">visibility</span>
             </button>
           </div>
+          <div class="text-right pt-1">
+            <a href="forgot-password.html" class="text-sm font-semibold text-ug-orange-pure hover:text-ug-orange transition-colors">¿Olvidaste tu contraseña?</a>
+          </div>
         </div>
 
         <!-- Error -->

--- a/front/perfil-organizacion.html
+++ b/front/perfil-organizacion.html
@@ -29,6 +29,7 @@
 <link href="assets/css/theme.css" rel="stylesheet"/>
 <script src="assets/js/session-guard.js"></script>
 <script src="assets/js/apiClient.js"></script>
+<script src="assets/js/change-password.js"></script>
 <script src="assets/js/confirmation-modal.js?v=2"></script>
 <script src="assets/js/mascot.js?v=2"></script>
 <script src="assets/js/theme-toggle.js"></script>
@@ -279,6 +280,15 @@
         </div>
       </div>
     </div>
+
+    <!-- Change password (only shown to the organization user on their own profile) -->
+    <section id="change-password-card" class="hidden card overflow-hidden mt-6">
+      <div class="px-6 py-4 border-b border-slate-100 flex items-center gap-2.5">
+        <span class="material-symbols-outlined text-xl" style="color: var(--c-orange);">lock_reset</span>
+        <h2 class="text-base font-semibold text-slate-800">Cambiar contraseña</h2>
+      </div>
+      <div id="change-password-section" class="px-6 py-5"></div>
+    </section>
   </div>
 </main>
 
@@ -303,6 +313,14 @@
   // Resolve org_id from URL or from user's profile
   const urlParams = new URLSearchParams(window.location.search);
   let orgIdFromUrl = urlParams.get('org_id') ? parseInt(urlParams.get('org_id'), 10) : null;
+
+  // Show the change-password form only when the organization user is viewing
+  // their own profile (not when another role is visiting via ?org_id=).
+  if (session?.rol === 'organizacion' && !orgIdFromUrl) {
+    const cpCard = document.getElementById('change-password-card');
+    if (cpCard) cpCard.classList.remove('hidden');
+    ChangePassword.init({ containerId: 'change-password-section', apiPath: '/me/password', authFetchFn: SessionGuard.authFetch });
+  }
 
   // Visitor mode: any non-organizacion user viewing an org sees only the org
   // identity, leaders/members, and stats — not its captures or volunteers.

--- a/front/reset-password.html
+++ b/front/reset-password.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Restablecer contraseña | Ecosistema VIDA UG</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet"/>
+<script id="tailwind-config">
+  tailwind.config = {
+    darkMode: "class",
+    theme: { extend: {
+      colors: {
+        "primary": "#2B063D", "primary-bold": "#3A0A4F",
+        "ug-orange": "#F15A24", "ug-orange-hover": "#E84B10",
+        "ug-orange-pure": "#FF5A1F", "warm-bg": "#FBF7F5",
+      },
+      fontFamily: { "display": ["Public Sans"] },
+      borderRadius: { "DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "2xl": "1rem", "full": "9999px" },
+    } },
+  }
+</script>
+<link href="assets/css/theme.css" rel="stylesheet"/>
+<script src="assets/js/apiClient.js"></script>
+<script src="assets/js/theme-toggle.js"></script>
+</head>
+<body class="font-display min-h-screen flex flex-col items-center justify-center bg-warm-bg px-4 py-10">
+
+<main class="w-full max-w-md">
+  <div class="bg-white rounded-2xl shadow-xl border border-slate-100 p-7 sm:p-9">
+
+    <div class="flex flex-col items-center text-center mb-6">
+      <div class="w-14 h-14 rounded-2xl bg-orange-50 border border-orange-100 flex items-center justify-center mb-3">
+        <span class="material-symbols-outlined text-3xl text-ug-orange-pure">lock_reset</span>
+      </div>
+      <h1 class="text-xl font-extrabold tracking-tight text-primary">Restablecer contraseña</h1>
+      <p class="text-slate-500 text-sm mt-1">Elegí una nueva contraseña para tu cuenta.</p>
+    </div>
+
+    <!-- Form -->
+    <form id="form-reset" class="space-y-4" novalidate>
+      <div class="space-y-1.5">
+        <label class="block text-xs font-semibold text-slate-600" for="password">Nueva contraseña</label>
+        <div class="relative">
+          <span class="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 text-lg pointer-events-none">lock</span>
+          <input id="password" name="password" type="password" autocomplete="new-password"
+            placeholder="Mínimo 8 caracteres" class="w-full pl-11 pr-11 py-3 text-sm"/>
+          <button type="button" id="toggle-pwd" class="absolute right-3.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-ug-orange-pure" tabindex="-1" aria-label="Mostrar/ocultar contraseña">
+            <span class="material-symbols-outlined text-lg" id="toggle-pwd-icon">visibility</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-1.5">
+        <label class="block text-xs font-semibold text-slate-600" for="confirm">Confirmar contraseña</label>
+        <div class="relative">
+          <span class="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 text-lg pointer-events-none">lock_reset</span>
+          <input id="confirm" name="confirm" type="password" autocomplete="new-password"
+            placeholder="Repetí la contraseña" class="w-full pl-11 pr-4 py-3 text-sm"/>
+        </div>
+      </div>
+
+      <p id="error-box" class="hidden text-red-600 text-sm bg-red-50 border border-red-200 rounded-lg px-4 py-2.5" role="alert"></p>
+
+      <button id="btn-submit" type="submit" class="btn-primary w-full py-3 text-sm rounded-xl flex items-center justify-center gap-2 disabled:opacity-60">
+        <span class="material-symbols-outlined text-lg">check_circle</span>
+        <span id="btn-text">Actualizar contraseña</span>
+      </button>
+    </form>
+
+    <!-- Success -->
+    <div id="success-box" class="hidden text-center space-y-4">
+      <div class="w-14 h-14 rounded-2xl bg-green-50 border border-green-100 flex items-center justify-center mx-auto">
+        <span class="material-symbols-outlined text-3xl text-green-600">task_alt</span>
+      </div>
+      <p id="success-text" class="text-slate-700 text-sm font-semibold">Contraseña actualizada. Ya podés iniciar sesión.</p>
+      <a href="login.html" class="btn-primary inline-flex items-center justify-center gap-2 px-6 py-3 text-sm rounded-xl">
+        <span class="material-symbols-outlined text-lg">login</span>
+        Ir al inicio de sesión
+      </a>
+    </div>
+  </div>
+</main>
+
+<script>
+  (function () {
+    "use strict";
+    var token = new URLSearchParams(location.search).get("token");
+    var form = document.getElementById("form-reset");
+    var errorBox = document.getElementById("error-box");
+    var successBox = document.getElementById("success-box");
+
+    function showError(msg) {
+      errorBox.textContent = msg;
+      errorBox.classList.remove("hidden");
+    }
+    function clearError() {
+      errorBox.textContent = "";
+      errorBox.classList.add("hidden");
+    }
+
+    if (!token) {
+      form.classList.add("hidden");
+      showError("Enlace inválido. Solicitá un nuevo enlace desde la pantalla de inicio de sesión.");
+      return;
+    }
+
+    document.getElementById("toggle-pwd").addEventListener("click", function () {
+      var input = document.getElementById("password");
+      var icon = document.getElementById("toggle-pwd-icon");
+      var show = input.type === "password";
+      input.type = show ? "text" : "password";
+      icon.textContent = show ? "visibility_off" : "visibility";
+    });
+
+    form.addEventListener("submit", async function (e) {
+      e.preventDefault();
+      clearError();
+      var password = document.getElementById("password").value;
+      var confirm = document.getElementById("confirm").value;
+
+      if (password.length < 8) {
+        showError("La contraseña debe tener al menos 8 caracteres.");
+        return;
+      }
+      if (password !== confirm) {
+        showError("Las contraseñas no coinciden.");
+        return;
+      }
+
+      var btn = document.getElementById("btn-submit");
+      var btnText = document.getElementById("btn-text");
+      btn.disabled = true;
+      btnText.textContent = "Actualizando…";
+
+      try {
+        var res = await ApiClient.fetch("/auth/reset-password", {
+          method: "POST", auth: false, json: { token: token, password: password },
+        });
+        var data = await res.json().catch(function () { return {}; });
+        if (!res.ok) {
+          showError(data.detail || "No se pudo actualizar la contraseña.");
+          return;
+        }
+        form.classList.add("hidden");
+        if (data.message) document.getElementById("success-text").textContent = data.message;
+        successBox.classList.remove("hidden");
+      } catch (_) {
+        showError("No se pudo conectar con el servidor. Intentá de nuevo.");
+      } finally {
+        btn.disabled = false;
+        btnText.textContent = "Actualizar contraseña";
+      }
+    });
+  })();
+</script>
+</body>
+</html>

--- a/front/set-password.html
+++ b/front/set-password.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<title>Activar cuenta | Ecosistema VIDA UG</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block" rel="stylesheet"/>
+<script id="tailwind-config">
+  tailwind.config = {
+    darkMode: "class",
+    theme: { extend: {
+      colors: {
+        "primary": "#2B063D", "primary-bold": "#3A0A4F",
+        "ug-orange": "#F15A24", "ug-orange-hover": "#E84B10",
+        "ug-orange-pure": "#FF5A1F", "warm-bg": "#FBF7F5",
+      },
+      fontFamily: { "display": ["Public Sans"] },
+      borderRadius: { "DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "2xl": "1rem", "full": "9999px" },
+    } },
+  }
+</script>
+<link href="assets/css/theme.css" rel="stylesheet"/>
+<script src="assets/js/apiClient.js"></script>
+<script src="assets/js/theme-toggle.js"></script>
+</head>
+<body class="font-display min-h-screen flex flex-col items-center justify-center bg-warm-bg px-4 py-10">
+
+<main class="w-full max-w-md">
+  <div class="bg-white rounded-2xl shadow-xl border border-slate-100 p-7 sm:p-9">
+
+    <div class="flex flex-col items-center text-center mb-6">
+      <div class="w-14 h-14 rounded-2xl bg-orange-50 border border-orange-100 flex items-center justify-center mb-3">
+        <span class="material-symbols-outlined text-3xl text-ug-orange-pure">password</span>
+      </div>
+      <h1 class="text-xl font-extrabold tracking-tight text-primary">Activá tu cuenta</h1>
+      <p class="text-slate-500 text-sm mt-1">Creá una contraseña para acceder al sistema.</p>
+    </div>
+
+    <!-- Form -->
+    <form id="form-set" class="space-y-4" novalidate>
+      <div class="space-y-1.5">
+        <label class="block text-xs font-semibold text-slate-600" for="password">Nueva contraseña</label>
+        <div class="relative">
+          <span class="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 text-lg pointer-events-none">lock</span>
+          <input id="password" name="password" type="password" autocomplete="new-password"
+            placeholder="Mínimo 8 caracteres" class="w-full pl-11 pr-11 py-3 text-sm"/>
+          <button type="button" id="toggle-pwd" class="absolute right-3.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-ug-orange-pure" tabindex="-1" aria-label="Mostrar/ocultar contraseña">
+            <span class="material-symbols-outlined text-lg" id="toggle-pwd-icon">visibility</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-1.5">
+        <label class="block text-xs font-semibold text-slate-600" for="confirm">Confirmar contraseña</label>
+        <div class="relative">
+          <span class="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400 text-lg pointer-events-none">lock_reset</span>
+          <input id="confirm" name="confirm" type="password" autocomplete="new-password"
+            placeholder="Repetí la contraseña" class="w-full pl-11 pr-4 py-3 text-sm"/>
+        </div>
+      </div>
+
+      <p id="error-box" class="hidden text-red-600 text-sm bg-red-50 border border-red-200 rounded-lg px-4 py-2.5" role="alert"></p>
+
+      <button id="btn-submit" type="submit" class="btn-primary w-full py-3 text-sm rounded-xl flex items-center justify-center gap-2 disabled:opacity-60">
+        <span class="material-symbols-outlined text-lg">check_circle</span>
+        <span id="btn-text">Activar cuenta</span>
+      </button>
+    </form>
+
+    <!-- Success -->
+    <div id="success-box" class="hidden text-center space-y-4">
+      <div class="w-14 h-14 rounded-2xl bg-green-50 border border-green-100 flex items-center justify-center mx-auto">
+        <span class="material-symbols-outlined text-3xl text-green-600">task_alt</span>
+      </div>
+      <p id="success-text" class="text-slate-700 text-sm font-semibold">¡Cuenta activada!</p>
+      <a href="login.html" class="btn-primary inline-flex items-center justify-center gap-2 px-6 py-3 text-sm rounded-xl">
+        <span class="material-symbols-outlined text-lg">login</span>
+        Ir al inicio de sesión
+      </a>
+    </div>
+  </div>
+</main>
+
+<script>
+  (function () {
+    "use strict";
+    var token = new URLSearchParams(location.search).get("token");
+    var form = document.getElementById("form-set");
+    var errorBox = document.getElementById("error-box");
+    var successBox = document.getElementById("success-box");
+
+    function showError(msg) {
+      errorBox.textContent = msg;
+      errorBox.classList.remove("hidden");
+    }
+    function clearError() {
+      errorBox.textContent = "";
+      errorBox.classList.add("hidden");
+    }
+
+    if (!token) {
+      form.classList.add("hidden");
+      showError("Enlace inválido. Solicitá al administrador que te reenvíe la invitación.");
+      return;
+    }
+
+    document.getElementById("toggle-pwd").addEventListener("click", function () {
+      var input = document.getElementById("password");
+      var icon = document.getElementById("toggle-pwd-icon");
+      var show = input.type === "password";
+      input.type = show ? "text" : "password";
+      icon.textContent = show ? "visibility_off" : "visibility";
+    });
+
+    form.addEventListener("submit", async function (e) {
+      e.preventDefault();
+      clearError();
+      var password = document.getElementById("password").value;
+      var confirm = document.getElementById("confirm").value;
+
+      if (password.length < 8) {
+        showError("La contraseña debe tener al menos 8 caracteres.");
+        return;
+      }
+      if (password !== confirm) {
+        showError("Las contraseñas no coinciden.");
+        return;
+      }
+
+      var btn = document.getElementById("btn-submit");
+      var btnText = document.getElementById("btn-text");
+      btn.disabled = true;
+      btnText.textContent = "Activando…";
+
+      try {
+        var res = await ApiClient.fetch("/auth/set-password", {
+          method: "POST", auth: false, json: { token: token, password: password },
+        });
+        var data = await res.json().catch(function () { return {}; });
+        if (!res.ok) {
+          showError(data.detail || "No se pudo activar la cuenta.");
+          return;
+        }
+        form.classList.add("hidden");
+        if (data.message) document.getElementById("success-text").textContent = data.message;
+        successBox.classList.remove("hidden");
+      } catch (_) {
+        showError("No se pudo conectar con el servidor. Intentá de nuevo.");
+      } finally {
+        btn.disabled = false;
+        btnText.textContent = "Activar cuenta";
+      }
+    });
+  })();
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiofiles==23.2.1
 pydantic==2.7.4
 psycopg2-binary==2.9.9
 supabase==2.7.4
+httpx>=0.27,<1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1


### PR DESCRIPTION
## Summary

Replaces admin-set passwords with **verification-by-delivery** onboarding, and adds full password self-service for all 4 roles.

- **Passwordless user creation**: admin creates a user with email only; account starts `activo=FALSE` with `password_hash NULL`. A single-use invite link (72h TTL) is emailed via Resend; setting the password activates the account (proves the email exists and is owned).
- **Admin UI**: password field removed, 3-state badge (Activo / Pendiente / Inactivo), "Reenviar invitación" action.
- **Password flows** (`backend/routers/password.py`): `POST /auth/forgot-password` (enumeration-safe generic 200), `POST /auth/reset-password` (1h token), `POST /auth/set-password` (invite activation), `POST /me/password` (authenticated change, all roles), `POST /usuarios/{id}/reenviar-invitacion` (admin).
- **Token security**: `secrets.token_urlsafe(32)`, only sha256 stored, single-use via atomic `UPDATE … RETURNING`, typed (`invite`/`reset`), prior tokens invalidated on reissue.
- **Email** (`backend/utils/email.py`): Resend REST via httpx, 10s timeout, fail-open on create (user stays Pendiente; admin resends). Spanish copy, personalized greeting.
- **Frontend**: `set-password.html`, `reset-password.html`, `forgot-password.html`, login "¿Olvidaste tu contraseña?" link, shared `change-password.js` component wired into all role profiles.
- **Migration `0024_password_tokens.sql`** (already applied live): `password_tokens` table + RLS `app_runtime_all` policy, `usuarios.password_hash` made nullable. Login already gates on `activo`, plus explicit NULL-hash guard in `_verify_password`.

## size:exception

Single PR by explicit maintainer decision (SDD delivery strategy "un solo PR grande"). The change is one cohesive auth feature; the SDD artifacts (spec: 12 requirements / 31 scenarios, verify report: PASS, 0 CRITICAL) live in engram under `sdd/auth-email-onboarding/*`.

## Config required (deploy)

| Env var | Value |
| --- | --- |
| `RESEND_API_KEY` | Resend API key |
| `EMAIL_FROM` | Sender; default `onboarding@resend.dev` (dev-only: delivers only to the Resend account owner until a domain is verified) |
| `APP_BASE_URL` | Public base URL for building email links |

## Test plan

- New suites `test_email.py`, `test_password_flows.py`, extended `test_usuarios.py` (TDD-first; local pytest run blocked by known env issues — see repo memory — all files compile clean).
- Manual: create user → Pendiente badge → invite link sets password → account Activo → login works; forgot-password → reset link → new password; change password from each role profile.