### PR TITLE
fix(db): remove leftover references to columns dropped in migration 0023

### DIFF
--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -485,7 +485,6 @@ def _build_tutor_params(body: GuardarBorradorRequest, numero: int, beneficiario_
         g("num_hijos") if g("num_hijos") is not None else 0,
         g("vivienda"),
         None if g("sin_empleo") else (g("fuente_empleo")),
-        None,
         0 if g("sin_empleo") else (g("ingreso_mensual") or 0),
         1 if g("imss_estatus") == "SI" else 0 if g("imss_estatus") == "NO" else None,
         1 if g("infonavit_estatus") == "SI" else 0 if g("infonavit_estatus") == "NO" else None,
@@ -597,11 +596,11 @@ def _create_borrador(
                     """
                     INSERT INTO tutores
                         (beneficiario_id, numero_tutor, nombre, email, edad, nivel_estudios,
-                         estado_civil, num_hijos, vivienda, fuente_empleo, antiguedad,
+                         estado_civil, num_hijos, vivienda, fuente_empleo,
                          ingreso_mensual, tiene_imss, tiene_infonavit,
                          antiguedad_meses, antiguedad_aplica, sin_empleo,
                          otras_fuentes_aplica, otras_fuentes_ingreso, monto_otras_fuentes)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     params,
                 )
@@ -761,11 +760,11 @@ def _update_borrador(
                     """
                     INSERT INTO tutores
                         (beneficiario_id, numero_tutor, nombre, email, edad, nivel_estudios,
-                         estado_civil, num_hijos, vivienda, fuente_empleo, antiguedad,
+                         estado_civil, num_hijos, vivienda, fuente_empleo,
                          ingreso_mensual, tiene_imss, tiene_infonavit,
                          antiguedad_meses, antiguedad_aplica, sin_empleo,
                          otras_fuentes_aplica, otras_fuentes_ingreso, monto_otras_fuentes)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                     params,
                 )

--- a/backend/routers/perfiles.py
+++ b/backend/routers/perfiles.py
@@ -363,8 +363,6 @@ def get_my_beneficiarios(
             e.id                      AS estudio_id,
             e.beneficiario_id,
             e.usuario_id,
-            e.otras_fuentes_ingreso,
-            e.monto_otras_fuentes,
             e.tuvo_silla_previa,
             e.como_obtuvo_silla,
             e.elaboro_estudio,

--- a/backend/routers/socioeconomico.py
+++ b/backend/routers/socioeconomico.py
@@ -1209,11 +1209,11 @@ def _insertar_tutores(db: _DBAdapter, beneficiario_id: int, tutores: list[TutorI
             """
             INSERT INTO tutores
                 (beneficiario_id, numero_tutor, nombre, email, edad, nivel_estudios,
-                 estado_civil, num_hijos, vivienda, fuente_empleo, antiguedad,
+                 estado_civil, num_hijos, vivienda, fuente_empleo,
                  ingreso_mensual, tiene_imss, tiene_infonavit,
                   antiguedad_meses, antiguedad_aplica, sin_empleo,
                   otras_fuentes_aplica, otras_fuentes_ingreso, monto_otras_fuentes)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 beneficiario_id,
@@ -1226,7 +1226,6 @@ def _insertar_tutores(db: _DBAdapter, beneficiario_id: int, tutores: list[TutorI
                 tutor.num_hijos if tutor.num_hijos is not None else 0,
                 tutor.vivienda or None,
                 None if tutor.sin_empleo else (tutor.fuente_empleo or None),
-                None,
                 0 if tutor.sin_empleo else tutor.ingreso_mensual,
                 _mapear_a_db(tutor.imss_estatus),
                 _mapear_a_db(tutor.infonavit_estatus),


### PR DESCRIPTION
## Summary

Production hotfix. Migration 0023 dropped dead columns, but three runtime references survived the cleanup in PR #148:

- **`GET /me/beneficiarios`** (`backend/routers/perfiles.py`) still selected `e.otras_fuentes_ingreso` and `e.monto_otras_fuentes` → the query 500s → the capturista profile shows an empty "beneficiarios registrados" list even though the stats counters (different endpoint) count the drafts. This is the bug reported in production.
- **Three `INSERT INTO tutores`** statements (`guardar_borrador.py` ×2, `socioeconomico.py` ×1) still included the dropped `antiguedad` column → any draft/study save carrying tutor data would 500.

Fix: removed the dropped columns from the SELECT and the INSERT column lists plus their positional params. Verified the corrected SELECT against the live Supabase schema (returns the previously hidden draft).

## Test plan
- Live SQL validation of the corrected `/me/beneficiarios` query (returns rows).
- `python3 -m py_compile` on the three routers.
- Manual after deploy: capturista profile lists the existing draft; saving a draft with tutor data succeeds.