### PR TITLE
fix(frontend): make uppercase normalization opt-in

### DIFF
--- a/front/Capturista-view/gestion.html
+++ b/front/Capturista-view/gestion.html
@@ -186,6 +186,7 @@
                 name="entidad_solicitante"
                 placeholder="Nombre de la institución o particular"
                 type="text"
+                data-uppercase="true"
                 minlength="2"
                 maxlength="64"
                 pattern="^[a-zA-ZáéíóúÁÉÍÓÚäëïöüÄËÏÖÜñÑ0-9 ()\/\-.,]*$"

--- a/front/Capturista-view/socioeconomico.html
+++ b/front/Capturista-view/socioeconomico.html
@@ -114,6 +114,7 @@
                 class="w-full"
                 name="nombres"
                 type="text"
+                data-uppercase="true"
                 minlength="2"
                 maxlength="60"
                 pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -129,6 +130,7 @@
                 class="w-full"
                 name="apellido_paterno"
                 type="text"
+                data-uppercase="true"
                 minlength="2"
                 maxlength="40"
                 pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -144,6 +146,7 @@
                 class="w-full"
                 name="apellido_materno"
                 type="text"
+                data-uppercase="true"
                 minlength="2"
                 maxlength="40"
                 pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -159,6 +162,7 @@
                 class="w-full uppercase"
                 name="curp"
                 type="text"
+                data-uppercase="true"
                 minlength="18"
                 maxlength="18"
                 pattern="^[A-Z][AEIOUX][A-Z]{2}\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])[HM](AS|BC|BS|CC|CL|CM|CS|CH|DF|DG|GT|GR|HG|JC|MC|MN|MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d]\d$"
@@ -190,6 +194,7 @@
                 class="w-full"
                 name="calle"
                 type="text"
+                data-uppercase="true"
                 minlength="3"
                 maxlength="120"
                 pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9.\- ]+$"
@@ -200,7 +205,7 @@
             </div>
             <div class="space-y-2">
               <label class="block text-sm font-semibold text-slate-700">Número exterior</label>
-              <input class="w-full" name="num_ext" type="text" minlength="1" maxlength="10" pattern="[A-Za-z0-9\-\/]{1,10}" required aria-describedby="num_ext-error" />
+              <input class="w-full" name="num_ext" type="text" data-uppercase="true" minlength="1" maxlength="10" pattern="[A-Za-z0-9\-\/]{1,10}" required aria-describedby="num_ext-error" />
               <p class="field-error hidden text-red-600 text-xs mt-1" id="num_ext-error" data-error-for="num_ext" role="alert"></p>
             </div>
             <div class="space-y-2">
@@ -208,7 +213,7 @@
                 <input class="h-4 w-4" name="tiene_num_interior" type="checkbox" />
                 <span>Agregar número interior</span>
               </label>
-              <input class="w-full text-slate-400 cursor-not-allowed" name="num_int" type="text" minlength="1" maxlength="10" pattern="[A-Za-z0-9\-\/]{0,10}" disabled />
+              <input class="w-full text-slate-400 cursor-not-allowed" name="num_int" type="text" data-uppercase="true" minlength="1" maxlength="10" pattern="[A-Za-z0-9\-\/]{0,10}" disabled />
             </div>
             <div class="space-y-2">
               <label class="block text-sm font-semibold text-slate-700"
@@ -218,6 +223,7 @@
                 class="w-full"
                 name="colonia"
                 type="text"
+                data-uppercase="true"
                 minlength="2"
                 maxlength="120"
                 pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9.\- ]+$"
@@ -304,6 +310,7 @@
                       class="w-full mt-1"
                       name="tutor1_nombres"
                       type="text"
+                      data-uppercase="true"
                       minlength="2"
                       maxlength="60"
                       pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -319,6 +326,7 @@
                       class="w-full mt-1"
                       name="tutor1_apellido_paterno"
                       type="text"
+                      data-uppercase="true"
                       minlength="2"
                       maxlength="40"
                       pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -334,6 +342,7 @@
                       class="w-full mt-1"
                       name="tutor1_apellido_materno"
                       type="text"
+                      data-uppercase="true"
                       minlength="2"
                       maxlength="40"
                       pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -442,6 +451,7 @@
                     class="w-full mt-1"
                     name="tutor1_fuente_empleo"
                     type="text"
+                    data-uppercase="true"
                     minlength="2"
                     maxlength="80"
                     pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9\s\-().\/.,]+$"
@@ -485,7 +495,7 @@
                 </label>
                 <div>
                   <label class="text-xs font-bold text-slate-500 uppercase">Otra fuente</label>
-                  <input class="w-full mt-1" name="tutor1_otras_fuentes_ingreso" type="text" minlength="2" maxlength="100" pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9\s\-().\/.,]+$" disabled aria-describedby="tutor1_otras_fuentes_ingreso-error" />
+                  <input class="w-full mt-1" name="tutor1_otras_fuentes_ingreso" type="text" data-uppercase="true" minlength="2" maxlength="100" pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9\s\-().\/.,]+$" disabled aria-describedby="tutor1_otras_fuentes_ingreso-error" />
                   <p class="field-error hidden text-red-600 text-xs mt-1" id="tutor1_otras_fuentes_ingreso-error" data-error-for="tutor1_otras_fuentes_ingreso" role="alert"></p>
                 </div>
                 <div>
@@ -563,6 +573,7 @@
                       class="w-full mt-1"
                       name="tutor2_nombres"
                       type="text"
+                      data-uppercase="true"
                       minlength="2"
                       maxlength="60"
                       pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -577,6 +588,7 @@
                       class="w-full mt-1"
                       name="tutor2_apellido_paterno"
                       type="text"
+                      data-uppercase="true"
                       minlength="2"
                       maxlength="40"
                       pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -591,6 +603,7 @@
                       class="w-full mt-1"
                       name="tutor2_apellido_materno"
                       type="text"
+                      data-uppercase="true"
                       minlength="2"
                       maxlength="40"
                       pattern="^[A-Za-zÁÉÍÓÚÜÑáéíóúüñ. ]+$"
@@ -693,6 +706,7 @@
                     class="w-full mt-1"
                     name="tutor2_fuente_empleo"
                     type="text"
+                    data-uppercase="true"
                     minlength="2"
                     maxlength="80"
                     pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9\s\-().\/.,]+$"
@@ -736,7 +750,7 @@
                 </label>
                 <div>
                   <label class="text-xs font-bold text-slate-500 uppercase">Otra fuente</label>
-                  <input class="w-full mt-1" name="tutor2_otras_fuentes_ingreso" type="text" minlength="2" maxlength="100" pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9\s\-().\/.,]+$" disabled aria-describedby="tutor2_otras_fuentes_ingreso-error" />
+                  <input class="w-full mt-1" name="tutor2_otras_fuentes_ingreso" type="text" data-uppercase="true" minlength="2" maxlength="100" pattern="^[A-Za-záéíóúÁÉÍÓÚüÜñÑ0-9\s\-().\/.,]+$" disabled aria-describedby="tutor2_otras_fuentes_ingreso-error" />
                   <p class="field-error hidden text-red-600 text-xs mt-1" id="tutor2_otras_fuentes_ingreso-error" data-error-for="tutor2_otras_fuentes_ingreso" role="alert"></p>
                 </div>
                 <div>

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -1402,9 +1402,9 @@
             (hasTutor2Data ? '<button type="button" id="btn-delete-tutor2" class="text-xs font-bold text-red-600 hover:text-red-700 bg-red-50 hover:bg-red-100 px-3 py-1.5 rounded-lg">Eliminar Tutor 2</button>' : '') +
             '</div>' +
             '<div class="grid grid-cols-3 gap-3">' +
-            _field(p + "nombres", "Nombre(s)", "text", { maxlength: 60, required: true }) +
-            _field(p + "apellido_paterno", "Apellido Paterno", "text", { maxlength: 40, required: true }) +
-            _field(p + "apellido_materno", "Apellido Materno", "text", { maxlength: 40 }) +
+            _field(p + "nombres", "Nombre(s)", "text", { maxlength: 60, required: true, "data-uppercase": "true" }) +
+            _field(p + "apellido_paterno", "Apellido Paterno", "text", { maxlength: 40, required: true, "data-uppercase": "true" }) +
+            _field(p + "apellido_materno", "Apellido Materno", "text", { maxlength: 40, "data-uppercase": "true" }) +
             '</div>' +
             '<div class="grid grid-cols-2 gap-3">' +
             _field(p + "edad", "Edad", "number", { min: 0, max: 99, required: true }) +
@@ -1416,7 +1416,7 @@
             '</div>' +
             '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Vivienda</label><select id="field-' + p + 'vivienda" name="' + p + 'vivienda" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3" required>' + vivOpts + '</select></div>' +
             '<div class="space-y-2">' +
-            _field(p + "fuente_empleo", "Fuente Empleo", "text", { maxlength: 80 }) +
+            _field(p + "fuente_empleo", "Fuente Empleo", "text", { maxlength: 80, "data-uppercase": "true" }) +
             '</div>' +
             '<div class="grid grid-cols-2 gap-3">' +
             _field(p + "antiguedad_anios", "Antigüedad (años)", "number", { min: 0, max: 50 }) +
@@ -1427,7 +1427,7 @@
             '<input id="field-' + p + 'ingreso_mensual" name="' + p + 'ingreso_mensual" type="text" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3" />' +
             '</div>' +
             '<div class="grid grid-cols-2 gap-3">' +
-            _field(p + "otras_fuentes_ingreso", "Otra fuente", "text", { maxlength: 100 }) +
+            _field(p + "otras_fuentes_ingreso", "Otra fuente", "text", { maxlength: 100, "data-uppercase": "true" }) +
             '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Monto adicional ($)</label><input id="field-' + p + 'monto_otras_fuentes" name="' + p + 'monto_otras_fuentes" type="text" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3" /></div>' +
             '</div>' +
             '<fieldset class="mt-3"><legend class="text-xs font-bold text-slate-500 uppercase">IMSS</legend><div class="flex gap-4 mt-1">' +
@@ -1459,16 +1459,16 @@
         return '' +
           '<h3 class="text-sm font-bold text-slate-700 mb-3">Datos del Beneficiario</h3>' +
           '<div class="grid grid-cols-2 gap-3">' +
-          _field("nombres", "Nombres", "text", { maxlength: 60, required: true }) +
-          _field("apellido_paterno", "Apellido Paterno", "text", { maxlength: 40, required: true }) +
-          _field("apellido_materno", "Apellido Materno", "text", { maxlength: 40 }) +
+          _field("nombres", "Nombres", "text", { maxlength: 60, required: true, "data-uppercase": "true" }) +
+          _field("apellido_paterno", "Apellido Paterno", "text", { maxlength: 40, required: true, "data-uppercase": "true" }) +
+          _field("apellido_materno", "Apellido Materno", "text", { maxlength: 40, "data-uppercase": "true" }) +
           _field("fecha_nacimiento", "Fecha de Nacimiento", "date") +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Sexo</label><select id="field-sexo" name="sexo" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3"><option value="M" ' + (sexoChecked === "M" ? "selected" : "") + '>Masculino</option><option value="F" ' + (sexoChecked === "F" ? "selected" : "") + '>Femenino</option></select></div>' +
           _fieldArea("diagnostico", "Diagnóstico", { maxlength: 160 }) +
-          _field("calle", "Calle", "text", { maxlength: 120 }) +
-          _field("num_ext", "Núm. Ext.", "text", { maxlength: 10 }) +
-          _field("num_int", "Núm. Int.", "text", { maxlength: 10 }) +
-          _field("colonia", "Colonia", "text", { maxlength: 120 }) +
+          _field("calle", "Calle", "text", { maxlength: 120, "data-uppercase": "true" }) +
+          _field("num_ext", "Núm. Ext.", "text", { maxlength: 10, "data-uppercase": "true" }) +
+          _field("num_int", "Núm. Int.", "text", { maxlength: 10, "data-uppercase": "true" }) +
+          _field("colonia", "Colonia", "text", { maxlength: 120, "data-uppercase": "true" }) +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Estado</label><select id="field-estado_codigo" name="estado_codigo" data-searchable class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3">' + estOpts + '</select></div>' +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Ciudad / Municipio</label><select id="field-ciudad" name="ciudad" data-searchable class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3" disabled><option value="">Selecciona un estado primero</option></select></div>' +
           _field("telefonos", "Teléfono (10 dígitos)", "tel", { maxlength: 10 }) +
@@ -1484,9 +1484,9 @@
           '</div>' +
           '<h3 class="text-sm font-bold text-slate-700 mb-3 mt-4 pt-4 border-t border-slate-100">Datos del Estudio</h3>' +
           '<div class="grid grid-cols-2 gap-3">' +
-          _field("sede", "Sede", "text", { maxlength: 80, required: true }) +
+          _field("sede", "Sede", "text", { maxlength: 80, required: true, "data-uppercase": "true" }) +
           _field("fecha_estudio", "Fecha de Estudio", "date", { required: true }) +
-          _field("ciudad_registro", "Ciudad de Registro", "text", { maxlength: 80, required: true }) +
+          _field("ciudad_registro", "Ciudad de Registro", "text", { maxlength: 80, required: true, "data-uppercase": "true" }) +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">¿Tuvo silla previa?</label><select id="field-tuvo_silla_previa" name="tuvo_silla_previa" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3"><option value="false" ' + (draft.tuvo_silla_previa === "false" ? "selected" : "") + '>No</option><option value="true" ' + (draft.tuvo_silla_previa === "true" ? "selected" : "") + '>Sí</option></select></div>' +
           '<div class="space-y-1"><label class="text-xs font-semibold text-slate-500">Cómo obtuvo silla</label><select id="field-como_obtuvo_silla" name="como_obtuvo_silla" class="w-full text-sm border-2 border-slate-200 rounded-xl bg-slate-50 py-2 px-3"><option value="">Selecciona una opción</option><option value="COMPRA">Compra</option><option value="DONACION">Donación</option></select></div>' +
           // Issue #106: status es solo lectura — el admin no puede revertir completo->borrador.
@@ -1531,7 +1531,7 @@
           </div>
           <h3 class="text-sm font-bold text-slate-700 mb-3">Gestión de Donación</h3>
           <div class="grid grid-cols-2 gap-3">
-            ${_field("entidad_solicitante", "Entidad Solicitante", "text", { maxlength: 64 })}
+            ${_field("entidad_solicitante", "Entidad Solicitante", "text", { maxlength: 64, "data-uppercase": "true" })}
             ${_select("prioridad", "Prioridad", prioridades)}
             ${_fieldArea("justificacion", "Justificación", { maxlength: 500 })}
           </div>`;

--- a/front/admin-beneficiarios.html
+++ b/front/admin-beneficiarios.html
@@ -1542,7 +1542,10 @@
         var extraParts = [];
         Object.keys(attrs).forEach(function(k) {
           var v = attrs[k];
-          if (v === true || v === "true") { extraParts.push(k); }
+          // data-* attributes must keep their value: validations.js matches
+          // data-uppercase === "true", so a bare attribute would disable it.
+          if (k.indexOf("data-") === 0) { if (v != null) extraParts.push(k + '="' + v + '"'); }
+          else if (v === true || v === "true") { extraParts.push(k); }
           else if (v !== false && v !== "false" && v != null) { extraParts.push(k + '="' + v + '"'); }
         });
         var extra = extraParts.join(" ");

--- a/front/assets/js/validations.js
+++ b/front/assets/js/validations.js
@@ -808,26 +808,15 @@
   }
 
   // ─────────────────────────────────────────────────────────────────
-  // Auto-uppercase: free-text inputs and textareas are uppercased as
-  // the user types, mirroring the backend's normalize_text so data is
-  // stored and displayed in a single canonical format.
-  // Opt out per field with the data-no-uppercase attribute.
+  // Auto-uppercase: explicit opt-in only. Add data-uppercase="true" to
+  // fields that must be stored in uppercase; free-text fields keep user casing.
   // ─────────────────────────────────────────────────────────────────
-
-  // Allowlist: only free-text controls. Radios/checkboxes are HTMLInputElements
-  // too and fire "input" on selection — uppercasing their value would corrupt
-  // catalog payloads (e.g. prioridad "Alta" -> "ALTA").
-  const UPPERCASE_ALLOWED_TYPES = new Set(["text"]);
-  const UPPERCASE_EXCLUDED_NAME_RE = /(email|password|contrasena|search|buscar)/i;
 
   function shouldAutoUppercase(el) {
     const isInput = el instanceof HTMLInputElement;
     const isTextarea = el instanceof HTMLTextAreaElement;
     if (!isInput && !isTextarea) return false;
-    if (el.dataset && el.dataset.noUppercase !== undefined) return false;
-    if (isInput && !UPPERCASE_ALLOWED_TYPES.has((el.type || "text").toLowerCase())) return false;
-    if (UPPERCASE_EXCLUDED_NAME_RE.test(el.name || el.id || "")) return false;
-    return true;
+    return el.dataset?.uppercase === "true" || el.getAttribute("data-uppercase") === "true";
   }
 
   document.addEventListener("input", (event) => {

--- a/tests/test_tecnica_workbench_frontend_contract.py
+++ b/tests/test_tecnica_workbench_frontend_contract.py
@@ -7,6 +7,11 @@ ROOT = Path(__file__).resolve().parents[1]
 TECNICA_FILE = ROOT / "front" / "Tecnico-view" / "vista_tecnicos.html"
 ADMIN_USERS_FILE = ROOT / "front" / "Admin-view" / "admin-usuarios.html"
 REGION_FILE = ROOT / "front" / "Capturista-view" / "seleccion-region.html"
+VALIDATIONS_FILE = ROOT / "front" / "assets" / "js" / "validations.js"
+SOCIOECONOMICO_FILE = ROOT / "front" / "Capturista-view" / "socioeconomico.html"
+CAPTURISTA_TECNICA_FILE = ROOT / "front" / "Capturista-view" / "tecnica.html"
+GESTION_FILE = ROOT / "front" / "Capturista-view" / "gestion.html"
+ADMIN_BENEFICIARIOS_FILE = ROOT / "front" / "admin-beneficiarios.html"
 
 
 def _read(path: Path) -> str:
@@ -65,3 +70,26 @@ def test_region_flow_routes_tecnico_to_workbench_without_beneficiario_dependency
     assert "if (session.rol === 'tecnico')" in html
     assert "window.location.href = '../Tecnico-view/vista_tecnicos.html';" in html
     assert "localStorage.removeItem('beneficiario_id');" in html
+
+
+def test_frontend_uppercase_normalization_is_explicit_opt_in() -> None:
+    validations = _read(VALIDATIONS_FILE)
+    socio = _read(SOCIOECONOMICO_FILE)
+    tecnica = _read(CAPTURISTA_TECNICA_FILE)
+    gestion = _read(GESTION_FILE)
+    admin_beneficiarios = _read(ADMIN_BENEFICIARIOS_FILE)
+
+    assert 'data-uppercase="true"' in socio
+    assert 'dataset?.uppercase === "true"' in validations
+    assert "data-no-uppercase" not in validations
+    assert "UPPERCASE_EXCLUDED_NAME_RE" not in validations
+
+    assert 'name="curp"\n                type="text"\n                data-uppercase="true"' in socio
+    assert 'name="tutor1_nombres"\n                      type="text"\n                      data-uppercase="true"' in socio
+    assert 'name="tutor2_fuente_empleo"\n                    type="text"\n                    data-uppercase="true"' in socio
+    assert 'name="entidad_solicitante"\n                placeholder="Nombre de la institución o particular"\n                type="text"\n                data-uppercase="true"' in gestion
+    assert '_field("nombres", "Nombres", "text", { maxlength: 60, required: true, "data-uppercase": "true" })' in admin_beneficiarios
+
+    assert 'name="diagnostico"\n                type="text"\n                data-uppercase="true"' not in tecnica
+    assert 'id="padecimiento-otra-texto"\n                    data-uppercase="true"' not in tecnica
+    assert 'name="justificacion"\n                placeholder="Información adicional relevante sobre la necesidad de esta silla específica..."\n                rows="3"\n                data-uppercase="true"' not in gestion


### PR DESCRIPTION
Closes #117

## PR Type
- [x] New feature

## Summary
- Replaced the shared global auto-uppercase listener with explicit `data-uppercase="true"` opt-in behavior.
- Marked canonical uppercase fields in capturista and admin beneficiary edit flows.
- Added frontend contract coverage so narrative/catalog-sensitive fields stay unforced.

## Changes
| File | Change |
|------|--------|
| `front/assets/js/validations.js` | Makes uppercase normalization explicit opt-in only. |
| `front/Capturista-view/socioeconomico.html` | Adds `data-uppercase="true"` to canonical name, CURP, address, and tutor employment fields. |
| `front/Capturista-view/gestion.html` | Adds opt-in uppercase to entidad solicitante. |
| `front/admin-beneficiarios.html` | Adds opt-in uppercase to dynamically rendered admin edit fields. |
| `tests/test_tecnica_workbench_frontend_contract.py` | Adds a contract test for opt-in uppercase behavior. |

## Test Plan
- [x] `python -m compileall tests`
- [x] `git diff --check`
- [x] `python -m pytest tests/test_tecnica_workbench_frontend_contract.py::test_frontend_uppercase_normalization_is_explicit_opt_in`
- [ ] `python -m pytest tests/test_tecnica_workbench_frontend_contract.py` has unrelated pre-existing failures in 4 stale contract tests.

## Notes
- Issue #117 currently lacks `status:approved`; this may fail the repository approval-label check.
- The full contract file now runs under pytest, but 4 unrelated tests fail because the current frontend no longer contains the expected technical workbench/admin review widget strings: `search-q`, Phase 2 operational endpoint literals, `renderReadonlySnapshot`, and `tecnica-revisiones-card`.

## Contributor Checklist
- [x] Linked issue with `Closes #117`
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Added exactly one `type:*` label after creation