### PR TITLE
test(tecnica): cover equipo solicitado persistence

### DIFF
--- a/backend/tests/test_tecnica.py
+++ b/backend/tests/test_tecnica.py
@@ -52,6 +52,18 @@ def _create_user_and_login(client, admin_headers: dict, *, suffix: str, rol: str
 
 
 class TestTecnicaRbac:
+    def test_equipo_solicitado_persiste(self, client, capturista_headers, sample_estudio):
+        payload = _solicitud_payload(sample_estudio["beneficiario_id"])
+        payload["equipo_solicitado"] = "Silla de ruedas neurológica PCI"
+
+        create_response = client.post("/api/solicitudes", headers=capturista_headers, json=payload)
+        assert create_response.status_code == 201, create_response.text
+        solicitud_id = create_response.json()["solicitud_id"]
+
+        get_response = client.get(f"/api/solicitudes/{solicitud_id}", headers=capturista_headers)
+        assert get_response.status_code == 200, get_response.text
+        assert get_response.json()["equipo_solicitado"] == "Silla de ruedas neurológica PCI"
+
     def test_soporte_oxigeno_persiste(self, client, capturista_headers, sample_estudio):
         payload = _solicitud_payload(sample_estudio["beneficiario_id"])
         payload["soporte_oxigeno"] = True

--- a/tests/test_tecnica_equipo_solicitado_frontend.py
+++ b/tests/test_tecnica_equipo_solicitado_frontend.py
@@ -1,0 +1,41 @@
+"""Contract tests for equipo_solicitado in the capturista technical form."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TECNICA_FILE = ROOT / "front" / "Capturista-view" / "tecnica.html"
+
+
+def _read_tecnica_html() -> str:
+    return TECNICA_FILE.read_text(encoding="utf-8")
+
+
+def test_declares_equipo_solicitado_field() -> None:
+    html = _read_tecnica_html()
+
+    assert 'name="equipo_solicitado"' in html
+
+
+def test_collects_equipo_solicitado_into_tecnica_data_and_submit_payload() -> None:
+    html = _read_tecnica_html()
+
+    assert 'equipo_solicitado: get("equipo_solicitado") || null' in html
+    assert 'equipo_solicitado: tecnicaData.equipo_solicitado || null' in html
+
+
+def test_includes_equipo_solicitado_in_draft_save_payload() -> None:
+    html = _read_tecnica_html()
+
+    draft_save_section = html[html.index("async function guardarBorradorDesdeTecnica") :]
+    draft_save_section = draft_save_section[: draft_save_section.index('ApiClient.fetch("/guardar-borrador"')]
+
+    assert "const tecnicaData = getTecnicaFormData();" in draft_save_section
+    assert "const payload = {" in draft_save_section
+    assert 'equipo_solicitado: tecnicaData.equipo_solicitado || null' in draft_save_section
+
+
+def test_restores_equipo_solicitado_from_backend_and_local_draft() -> None:
+    html = _read_tecnica_html()
+
+    assert html.count('setVal("equipo_solicitado", data.equipo_solicitado);') >= 2


### PR DESCRIPTION
Closes #69

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds backend coverage proving `equipo_solicitado` persists through POST and GET for solicitudes técnicas.
- Adds frontend contract coverage so `tecnica.html` keeps collecting, sending, saving, and restoring `equipo_solicitado`.
- Replaces closed PR #144 with a tests-only PR; implementation and migration changes already exist in `branch-beta03`.

## Changes
| File | Change |
|------|--------|
| `backend/tests/test_tecnica.py` | Adds persistence coverage for `equipo_solicitado`. |
| `tests/test_tecnica_equipo_solicitado_frontend.py` | Adds frontend contract tests for the field lifecycle. |

## Test Plan
- [x] `python -m py_compile backend/tests/test_tecnica.py tests/test_tecnica_equipo_solicitado_frontend.py`
- [x] `python -m pytest tests/test_tecnica_equipo_solicitado_frontend.py backend/tests/test_tecnica.py -q`
- [x] `git diff --check`

## Contributor Checklist
- [x] Linked issue with `Closes #69`
- [x] Linked an approved issue: #69 has `status:approved`
- [x] Added exactly one `type:*` label: `type:chore`
- [x] Ran shellcheck on modified scripts: no shell scripts modified
- [x] Skills tested in at least one agent: not applicable
- [x] Docs updated if behavior changed: not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers