### PR TITLE
fix(frontend): corregir desfase de un día en última actividad (zona horaria)  

### DIFF
--- a/front/assets/js/common.js
+++ b/front/assets/js/common.js
@@ -37,7 +37,6 @@
         year: "numeric",
         month: "short",
         day: "numeric",
-        timeZone: "UTC",
       });
     } catch (_) {
       return iso;


### PR DESCRIPTION
Issue #72: eliminar timeZone UTC de _formatDate() para que use la zona horaria local del navegador.