### PR TITLE
refactor(config): módulo único de settings/config para secretos enchufables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,3 +19,8 @@ DB_PASSWORD=postgres
 # ---- Supabase Storage ----
 SUPABASE_URL=https://xxxxxxxxxxxx.supabase.co
 SUPABASE_SERVICE_KEY=tu-service-role-key
+
+# ---- Email (Resend) — opcional; solo requerido al enviar invitaciones/reset ----
+# RESEND_API_KEY=
+# EMAIL_FROM=onboarding@resend.dev
+# APP_BASE_URL=https://tu-dominio.example.com

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,10 +1,11 @@
-import os
 from contextlib import contextmanager
 from typing import Generator
 from urllib.parse import urlparse
 
 import psycopg2
 import psycopg2.extras
+
+import settings
 
 
 def _looks_like_test_value(value: str | None) -> bool:
@@ -63,10 +64,10 @@ def assert_test_database_target(
 
 def build_test_conn_kwargs() -> dict:
     """Build connection kwargs for tests honoring TEST_DATABASE_URL and schema guardrails."""
-    test_database_url = os.environ.get("TEST_DATABASE_URL")
-    test_schema = os.environ.get("TEST_DB_SCHEMA")
-    db_name = os.environ.get("DB_NAME", "postgres")
-    db_host = os.environ.get("DB_HOST")
+    test_database_url = settings.test_database_url()
+    test_schema = settings.test_db_schema()
+    db_name = settings.db_name()
+    db_host = settings.db_host_or_none()
 
     assert_test_database_target(
         db_name=db_name,
@@ -80,7 +81,7 @@ def build_test_conn_kwargs() -> dict:
     else:
         conn_kwargs = _build_conn_kwargs()
 
-    options = os.environ.get("TEST_DB_OPTIONS")
+    options = settings.test_db_options()
     if test_schema:
         schema_option = f"-c search_path={test_schema}"
         options = f"{options} {schema_option}".strip() if options else schema_option
@@ -92,13 +93,13 @@ def build_test_conn_kwargs() -> dict:
 
 
 def _build_conn_kwargs() -> dict:
-    """Build psycopg2 connection kwargs from environment variables."""
+    """Build psycopg2 connection kwargs from settings."""
     return dict(
-        host=os.environ["DB_HOST"],
-        port=int(os.environ.get("DB_PORT", "5432")),
-        dbname=os.environ.get("DB_NAME", "postgres"),
-        user=os.environ.get("DB_USER", "postgres"),
-        password=os.environ["DB_PASSWORD"],
+        host=settings.db_host(),
+        port=settings.db_port(),
+        dbname=settings.db_name(),
+        user=settings.db_user(),
+        password=settings.db_password(),
         sslmode="require",
     )
 

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -20,10 +20,10 @@ Why this file still exists (do not delete it):
   - `_init_storage()` provisions the Supabase Storage buckets.
 """
 
-import os
-
 import psycopg2
 from supabase import create_client
+
+import settings
 
 
 DDL = [
@@ -282,11 +282,11 @@ DDL = [
 
 def init() -> None:
     conn = psycopg2.connect(
-        host=os.environ["DB_HOST"],
-        port=int(os.environ.get("DB_PORT", "5432")),
-        dbname=os.environ.get("DB_NAME", "postgres"),
-        user=os.environ.get("DB_USER", "postgres"),
-        password=os.environ["DB_PASSWORD"],
+        host=settings.db_host(),
+        port=settings.db_port(),
+        dbname=settings.db_name(),
+        user=settings.db_user(),
+        password=settings.db_password(),
         sslmode="require",
     )
     try:
@@ -302,8 +302,8 @@ def init() -> None:
 
 def _init_storage() -> None:
     client = create_client(
-        os.environ["SUPABASE_URL"],
-        os.environ["SUPABASE_SERVICE_KEY"],
+        settings.supabase_url(),
+        settings.supabase_service_key(),
     )
     _ensure_private_bucket(
         client,

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from env_bootstrap import load_root_env_if_needed
 
 load_root_env_if_needed(__file__)
 
+import settings
 from routers import admin, auth, socioeconomico, tecnica, usuarios, regiones, perfiles, finalizar, guardar_borrador, password
 
 # Serve the frontend — path is resolved relative to this file so it works
@@ -51,8 +52,7 @@ def _cache_control_for_path(path: str) -> str:
 
 
 def create_app() -> FastAPI:
-    env = os.environ.get("ENV", "development").lower()
-    docs_enabled = env != "production"
+    docs_enabled = settings.env() != "production"
 
     app = FastAPI(
         title="Sillas Rotary API v2",

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -9,7 +9,6 @@ Replaces the old name-only capturista login with:
 - require_tecnico       — FastAPI dependency for tecnico-or-admin routes
 """
 
-import os
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
@@ -20,26 +19,20 @@ from passlib.context import CryptContext
 from passlib.exc import UnknownHashError
 from pydantic import BaseModel, field_validator
 
+import settings
 from database import get_db, _DBAdapter
 from validators import validate_email_format
 
 router = APIRouter()
 
 # ---------------------------------------------------------------------------
-# Config
+# Config — JWT_SECRET presence/strength is validated in settings.py at
+# import time, so importing this router already fails fast on a bad secret.
 # ---------------------------------------------------------------------------
 
-_JWT_SECRET = os.environ.get("JWT_SECRET")
-if not _JWT_SECRET or _JWT_SECRET == "dev-secret-change-in-production":
-    raise RuntimeError(
-        "JWT_SECRET environment variable must be set to a strong secret "
-        "(>=32 bytes). The placeholder 'dev-secret-change-in-production' is "
-        "not accepted."
-    )
-if len(_JWT_SECRET) < 32:
-    raise RuntimeError("JWT_SECRET must be at least 32 bytes long.")
-_JWT_ALGORITHM = "HS256"
-_JWT_EXPIRE_HOURS = int(os.environ.get("JWT_EXPIRE_HOURS", "8"))
+_JWT_SECRET = settings.JWT_SECRET
+_JWT_ALGORITHM = settings.JWT_ALGORITHM
+_JWT_EXPIRE_HOURS = settings.JWT_EXPIRE_HOURS
 
 _pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 _oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")

--- a/backend/routers/socioeconomico.py
+++ b/backend/routers/socioeconomico.py
@@ -21,6 +21,7 @@ from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, field_validator, model_validator
 from supabase import create_client
 
+import settings
 from database import get_db, _DBAdapter
 from audit import registrar_evento
 from routers.auth import CurrentUser, assert_resource_owner, require_roles
@@ -76,8 +77,8 @@ _DOCUMENT_SIGNED_URL_TTL_SECONDS = 60
 
 def _storage():
     return create_client(
-        os.environ["SUPABASE_URL"],
-        os.environ["SUPABASE_SERVICE_KEY"],
+        settings.supabase_url(),
+        settings.supabase_service_key(),
     ).storage.from_(_DOCUMENT_BUCKET)
 
 

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -12,6 +12,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, field_validator, model_validator, ValidationInfo
 from supabase import create_client
 
+import settings
 from database import get_db, _DBAdapter
 from audit import registrar_evento
 from routers.auth import CurrentUser, assert_resource_owner, require_roles
@@ -85,8 +86,8 @@ def _resolve_storage_url(raw_url: Optional[str], bucket: str) -> Optional[str]:
     try:
         from supabase import create_client
         storage = create_client(
-            os.environ["SUPABASE_URL"],
-            os.environ["SUPABASE_SERVICE_KEY"],
+            settings.supabase_url(),
+            settings.supabase_service_key(),
         ).storage.from_(bucket)
         signed_raw = storage.create_signed_url(path, 300)
         signed = _signed_url_from_response(signed_raw)
@@ -99,8 +100,8 @@ def _resolve_storage_url(raw_url: Optional[str], bucket: str) -> Optional[str]:
     try:
         from supabase import create_client
         storage = create_client(
-            os.environ["SUPABASE_URL"],
-            os.environ["SUPABASE_SERVICE_KEY"],
+            settings.supabase_url(),
+            settings.supabase_service_key(),
         ).storage.from_(bucket)
         return storage.get_public_url(path)
     except Exception:
@@ -344,8 +345,8 @@ def _classify_db_error(exc: Exception) -> HTTPException:
 def _storage(bucket: str = _BUCKET):
     from supabase import create_client
     return create_client(
-        os.environ["SUPABASE_URL"],
-        os.environ["SUPABASE_SERVICE_KEY"],
+        settings.supabase_url(),
+        settings.supabase_service_key(),
     ).storage.from_(bucket)
 
 

--- a/backend/seed_v2.py
+++ b/backend/seed_v2.py
@@ -13,22 +13,23 @@ Run AFTER migrate_v2.sql:
 Requires DB_HOST, DB_PASSWORD env vars (same as production).
 """
 
-import os
 import sys
 
 import psycopg2
 from passlib.context import CryptContext
+
+import settings
 
 _pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def _connect():
     return psycopg2.connect(
-        host=os.environ["DB_HOST"],
-        port=int(os.environ.get("DB_PORT", "5432")),
-        dbname=os.environ.get("DB_NAME", "postgres"),
-        user=os.environ.get("DB_USER", "postgres"),
-        password=os.environ["DB_PASSWORD"],
+        host=settings.db_host(),
+        port=settings.db_port(),
+        dbname=settings.db_name(),
+        user=settings.db_user(),
+        password=settings.db_password(),
         sslmode="require",
     )
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,155 @@
+"""
+Centralized configuration/secrets module (Issue #83).
+
+Before this module existed, `DB_*`, `SUPABASE_*`, `JWT_SECRET` and friends
+were read via scattered `os.environ[...]` / `os.environ.get(...)` calls across
+routers and scripts. That made it impossible to swap the config source (env
+vars today, AWS Secrets Manager / GCP Secret Manager tomorrow) without
+touching every call site.
+
+The rest of the codebase must import values from here instead of calling
+`os.environ` directly. To change the source later, only this file changes.
+
+Required settings are read lazily (on each call, not at import) so that
+`monkeypatch.setenv(...)` in tests keeps working and importing this module
+never has side effects beyond the JWT_SECRET boot check below, which mirrors
+the fail-fast validation `routers/auth.py` already performed before this
+module existed.
+"""
+
+import os
+
+
+class MissingSettingError(RuntimeError):
+    """Raised when a required environment variable is not set."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(
+            f"Falta la variable de entorno requerida '{name}'. "
+            "La aplicación no puede continuar sin ella."
+        )
+
+
+def _require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise MissingSettingError(name)
+    return value
+
+
+def _optional(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+# ---------------------------------------------------------------------------
+# App / runtime
+# ---------------------------------------------------------------------------
+
+def env() -> str:
+    return _optional("ENV", "development").lower()
+
+
+# ---------------------------------------------------------------------------
+# Database — direct psycopg2 connection (backend/database.py + bootstrap
+# scripts: init_db.py, setup_db.py, seed_v2.py)
+# ---------------------------------------------------------------------------
+
+def db_host() -> str:
+    return _require("DB_HOST")
+
+
+def db_host_or_none() -> str | None:
+    """Non-raising read of DB_HOST for heuristics (e.g. 'does this look like
+    a test target') where an unset value is a valid state, not an error."""
+    return os.environ.get("DB_HOST")
+
+
+def db_port() -> int:
+    return int(_optional("DB_PORT", "5432"))
+
+
+def db_name() -> str:
+    return _optional("DB_NAME", "postgres")
+
+
+def db_user() -> str:
+    return _optional("DB_USER", "postgres")
+
+
+def db_password() -> str:
+    return _require("DB_PASSWORD")
+
+
+# ---------------------------------------------------------------------------
+# Test database overrides (backend/tests) — not production secrets, but
+# centralized here too so database.py has a single settings import.
+# ---------------------------------------------------------------------------
+
+def test_database_url() -> str | None:
+    return os.environ.get("TEST_DATABASE_URL")
+
+
+def test_db_schema() -> str | None:
+    return os.environ.get("TEST_DB_SCHEMA")
+
+
+def test_db_options() -> str | None:
+    return os.environ.get("TEST_DB_OPTIONS")
+
+
+# ---------------------------------------------------------------------------
+# Supabase Storage — blobs only (fotos-tecnica, documentos-estudio buckets)
+# ---------------------------------------------------------------------------
+
+def supabase_url() -> str:
+    return _require("SUPABASE_URL")
+
+
+def supabase_service_key() -> str:
+    return _require("SUPABASE_SERVICE_KEY")
+
+
+# ---------------------------------------------------------------------------
+# JWT auth — validated eagerly at import time so the process fails fast on
+# boot with a clear message instead of failing deep inside a request handler.
+# ---------------------------------------------------------------------------
+
+JWT_ALGORITHM = "HS256"
+
+_jwt_secret = os.environ.get("JWT_SECRET")
+if not _jwt_secret or _jwt_secret == "dev-secret-change-in-production":
+    raise RuntimeError(
+        "JWT_SECRET environment variable must be set to a strong secret "
+        "(>=32 bytes). The placeholder 'dev-secret-change-in-production' is "
+        "not accepted."
+    )
+if len(_jwt_secret) < 32:
+    raise RuntimeError("JWT_SECRET must be at least 32 bytes long.")
+
+JWT_SECRET = _jwt_secret
+JWT_EXPIRE_HOURS = int(_optional("JWT_EXPIRE_HOURS", "8"))
+
+
+# ---------------------------------------------------------------------------
+# Email delivery (Resend) — backend/utils/email.py
+# ---------------------------------------------------------------------------
+
+def resend_api_key() -> str:
+    """Required only when an email is actually sent (fail-open callers)."""
+    return _require("RESEND_API_KEY")
+
+
+def email_from() -> str:
+    return _optional("EMAIL_FROM", "onboarding@resend.dev")
+
+
+def app_base_url() -> str:
+    """APP_BASE_URL without a trailing slash. Falls back to the
+    Vercel-injected deployment URL so preview deployments build working
+    email links without per-branch configuration."""
+    explicit = _optional("APP_BASE_URL").rstrip("/")
+    if explicit:
+        return explicit
+    vercel = _optional("VERCEL_URL")
+    return f"https://{vercel}" if vercel else ""

--- a/backend/setup_db.py
+++ b/backend/setup_db.py
@@ -41,17 +41,18 @@ _load_env_file(_ENV_PATH)
 
 import psycopg2
 
+import settings
 from init_db import init as init_v1
 from seed_v2 import seed as seed_v2
 
 
 def _connect():
     return psycopg2.connect(
-        host=os.environ["DB_HOST"],
-        port=int(os.environ.get("DB_PORT", "5432")),
-        dbname=os.environ.get("DB_NAME", "postgres"),
-        user=os.environ.get("DB_USER", "postgres"),
-        password=os.environ["DB_PASSWORD"],
+        host=settings.db_host(),
+        port=settings.db_port(),
+        dbname=settings.db_name(),
+        user=settings.db_user(),
+        password=settings.db_password(),
         sslmode="require",
     )
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for backend/settings.py (Issue #83 — centralized config module).
+
+settings.py has no external dependencies (stdlib `os` only), so these tests
+run even without the DB/Supabase driver stack installed.
+"""
+
+import importlib
+
+import pytest
+
+import settings
+
+
+def test_require_raises_clear_error_when_missing(monkeypatch):
+    monkeypatch.delenv("DB_HOST", raising=False)
+    with pytest.raises(settings.MissingSettingError, match="DB_HOST"):
+        settings.db_host()
+
+
+def test_require_returns_value_when_present(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "db.example.com")
+    assert settings.db_host() == "db.example.com"
+
+
+def test_optional_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("DB_NAME", raising=False)
+    assert settings.db_name() == "postgres"
+
+
+def test_optional_returns_explicit_value(monkeypatch):
+    monkeypatch.setenv("DB_NAME", "rotary_prod")
+    assert settings.db_name() == "rotary_prod"
+
+
+def test_db_host_or_none_does_not_raise_when_unset(monkeypatch):
+    monkeypatch.delenv("DB_HOST", raising=False)
+    assert settings.db_host_or_none() is None
+
+
+def test_supabase_settings_require_presence(monkeypatch):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    with pytest.raises(settings.MissingSettingError, match="SUPABASE_URL"):
+        settings.supabase_url()
+
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    with pytest.raises(settings.MissingSettingError, match="SUPABASE_SERVICE_KEY"):
+        settings.supabase_service_key()
+
+
+def test_resend_api_key_required_only_when_read(monkeypatch):
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    with pytest.raises(settings.MissingSettingError, match="RESEND_API_KEY"):
+        settings.resend_api_key()
+
+
+def test_app_base_url_falls_back_to_vercel_url(monkeypatch):
+    monkeypatch.delenv("APP_BASE_URL", raising=False)
+    monkeypatch.setenv("VERCEL_URL", "my-preview.vercel.app")
+    assert settings.app_base_url() == "https://my-preview.vercel.app"
+
+
+def test_app_base_url_empty_when_nothing_set(monkeypatch):
+    monkeypatch.delenv("APP_BASE_URL", raising=False)
+    monkeypatch.delenv("VERCEL_URL", raising=False)
+    assert settings.app_base_url() == ""
+
+
+class TestJwtSecretBootValidation:
+    """JWT_SECRET is validated once, at settings module import time, so a
+    missing/weak secret aborts the app boot with a clear message instead of
+    failing deep inside a request handler."""
+
+    def teardown_method(self) -> None:
+        # Restore the deterministic test secret conftest.py relies on and
+        # reload so later tests see a consistent settings.JWT_SECRET again.
+        import os
+
+        os.environ["JWT_SECRET"] = "test-secret-" + ("x" * 32)
+        importlib.reload(settings)
+
+    def test_missing_jwt_secret_aborts_import(self, monkeypatch):
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        with pytest.raises(RuntimeError, match="JWT_SECRET"):
+            importlib.reload(settings)
+
+    def test_placeholder_jwt_secret_aborts_import(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "dev-secret-change-in-production")
+        with pytest.raises(RuntimeError, match="placeholder"):
+            importlib.reload(settings)
+
+    def test_short_jwt_secret_aborts_import(self, monkeypatch):
+        monkeypatch.setenv("JWT_SECRET", "too-short")
+        with pytest.raises(RuntimeError, match="32 bytes"):
+            importlib.reload(settings)

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -17,13 +17,12 @@ admin can resend the invitation. Raw tokens appear only in the link and are
 never logged or persisted (only their sha256 hash is stored).
 """
 
-import os
-
 import httpx
+
+import settings
 
 _RESEND_ENDPOINT = "https://api.resend.com/emails"
 _TIMEOUT_SECONDS = 10.0
-_DEFAULT_FROM = "onboarding@resend.dev"
 
 
 class EmailDeliveryError(Exception):
@@ -32,8 +31,8 @@ class EmailDeliveryError(Exception):
 
 def _resend_post(to: str, subject: str, html: str) -> None:
     """POST a single email to Resend. Raises EmailDeliveryError on failure."""
-    api_key = os.environ["RESEND_API_KEY"]
-    from_addr = os.environ.get("EMAIL_FROM", _DEFAULT_FROM)
+    api_key = settings.resend_api_key()
+    from_addr = settings.email_from()
     try:
         resp = httpx.post(
             _RESEND_ENDPOINT,
@@ -58,20 +57,9 @@ def _resend_post(to: str, subject: str, html: str) -> None:
         raise EmailDeliveryError(f"Resend request failed: {exc}") from exc
 
 
-def _base_url() -> str:
-    """Return APP_BASE_URL without a trailing slash. Falls back to the
-    Vercel-injected deployment URL so preview deployments build working
-    email links without per-branch configuration."""
-    explicit = os.environ.get("APP_BASE_URL", "").rstrip("/")
-    if explicit:
-        return explicit
-    vercel_url = os.environ.get("VERCEL_URL", "")
-    return f"https://{vercel_url}" if vercel_url else ""
-
-
 def send_invite(to_email: str, raw_token: str, nombre: str) -> None:
     """Send the account-activation (invite) email. Valid for 72 hours."""
-    link = f"{_base_url()}/set-password.html?token={raw_token}"
+    link = f"{settings.app_base_url()}/set-password.html?token={raw_token}"
     html = f"""
     <p>Hola {nombre}:</p>
     <p>Tu cuenta en <strong>200 SILLAS 200 CAMPEONES</strong> ha sido creada.</p>
@@ -85,7 +73,7 @@ def send_invite(to_email: str, raw_token: str, nombre: str) -> None:
 
 def send_reset(to_email: str, raw_token: str) -> None:
     """Send the password-reset email. Valid for 1 hour."""
-    link = f"{_base_url()}/reset-password.html?token={raw_token}"
+    link = f"{settings.app_base_url()}/reset-password.html?token={raw_token}"
     html = f"""
     <p>Recibimos una solicitud para restablecer la contraseña de tu cuenta en
     <strong>200 SILLAS 200 CAMPEONES</strong>.</p>


### PR DESCRIPTION
Closes #83

## Resumen

- **Contexto**: las variables de entorno (`DB_*`, `SUPABASE_*`, `JWT_SECRET`, etc.) se leían con `os.environ` disperso en routers, `database.py` y scripts de bootstrap. Enchufar un gestor de secretos (AWS/GCP Secrets Manager) obligaría a tocar muchos archivos.
- **Solución**: nuevo módulo `backend/settings.py` que centraliza toda la lectura de config/secretos. El resto del código importa de ahí; mañana se cambia solo la fuente en un único lugar.

### Cambios

- `backend/settings.py` (nuevo): funciones `db_host()`, `db_port()`, `db_name()`, `db_user()`, `db_password()`, `supabase_url()`, `supabase_service_key()`, `resend_api_key()`, `email_from()`, `app_base_url()`, `env()`, y las variables de test (`test_database_url()`, `test_db_schema()`, `test_db_options()`).
  - Los valores requeridos se leen de forma perezosa (por llamada, no al importar) para no romper `monkeypatch.setenv(...)` en los tests existentes.
  - `JWT_SECRET` se valida de forma **eager** al importar el módulo (presencia + ≥32 bytes + rechazo del placeholder de desarrollo) — mismo comportamiento que ya tenía `routers/auth.py`, ahora centralizado.
  - `MissingSettingError` da un mensaje claro cuando falta una variable requerida, en vez de un `KeyError` críptico.
- Migrados a `settings`: `database.py`, `routers/auth.py`, `routers/socioeconomico.py`, `routers/tecnica.py`, `utils/email.py`, `main.py`, `init_db.py`, `setup_db.py`, `seed_v2.py`.
- `backend/.env.example`: documentadas las variables de email/app URL (`RESEND_API_KEY`, `EMAIL_FROM`, `APP_BASE_URL`) que no estaban documentadas, sin valores reales.
- `backend/tests/test_settings.py` (nuevo): cubre lectura de requeridas/opcionales, `MissingSettingError` con mensaje claro, y el arranque fallando con `RuntimeError` si `JWT_SECRET` falta / es el placeholder / es corto.

### No incluido intencionalmente

- `env_bootstrap.py` (carga de `.env` a `os.environ`) no se toca — es la *fuente* de las variables, no un consumidor de secretos.
- Las variables `TEST_DB_SCHEMA`/`TEST_DATABASE_URL` seteadas directamente en `tests/conftest.py` (fixtures de test) se mantienen igual — son infraestructura de test, no secretos de producción.

## Test plan

- [x] `python3 -m py_compile` sobre todos los módulos tocados.
- [x] Verificación manual (sin poder instalar dependencias en este entorno) de que `settings.py` reproduce exactamente el comportamiento de los tests existentes que hacen `monkeypatch.setenv(...)` sobre `DB_HOST`, `DB_NAME`, `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `RESEND_API_KEY`, `EMAIL_FROM`, `APP_BASE_URL` (`test_database_safety.py`, `test_storage_security_migration.py`, `test_email.py`).
- [ ] Correr la suite completa con `pytest` en un entorno con las dependencias instaladas (no fue posible en este sandbox: sin `pip`/`venv` disponible).

> Nota: este PR va contra `branch-beta03` (la base que usan los PRs recientes de este repo), no contra `main`. El cierre automático vía `Closes #83` solo lo dispara GitHub al mergear contra la rama **default** del repo (`main`); si el merge es a `branch-beta03`, probablemente el issue no se cierre solo — avisen si prefieren cerrarlo manualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)