### PR TITLE
fix(security): enforce case authorization and correlation

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,8 +5,10 @@ aiofiles==23.2.1
 pydantic==2.7.4
 psycopg2-binary==2.9.9
 supabase==2.7.4
+httpx>=0.27,<1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 email-validator==2.2.0
 openpyxl>=3.1.0
+pytest==8.4.2

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -268,6 +268,68 @@ def assert_resource_owner(
     )
 
 
+def _assert_case_pair(
+    *,
+    user: CurrentUser,
+    db: _DBAdapter,
+    estudio_id: int | None = None,
+    solicitud_id: int | None = None,
+    beneficiario_id: int | None = None,
+) -> tuple[dict, dict | None]:
+    """Authorize a case and prove all supplied records share one beneficiary."""
+    solicitud = None
+    if solicitud_id is not None:
+        solicitud = db.execute(
+            "SELECT id, usuario_id, beneficiario_id FROM solicitudes_tecnicas WHERE id = %s",
+            (solicitud_id,),
+        ).fetchone()
+        if solicitud is None:
+            raise HTTPException(status_code=404, detail="Solicitud no encontrada")
+
+    if estudio_id is not None:
+        estudio = db.execute(
+            "SELECT id, usuario_id, beneficiario_id FROM estudios_socioeconomicos WHERE id = %s",
+            (estudio_id,),
+        ).fetchone()
+    else:
+        lookup_beneficiario_id = beneficiario_id
+        if lookup_beneficiario_id is None and solicitud is not None:
+            lookup_beneficiario_id = solicitud["beneficiario_id"]
+        estudio = db.execute(
+            """
+            SELECT id, usuario_id, beneficiario_id
+            FROM estudios_socioeconomicos
+            WHERE beneficiario_id = %s
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (lookup_beneficiario_id,),
+        ).fetchone()
+
+    if estudio is None:
+        raise HTTPException(status_code=404, detail="Estudio no encontrado")
+
+    case_beneficiario_id = estudio["beneficiario_id"]
+    supplied_beneficiario_ids = [
+        value
+        for value in (
+            beneficiario_id,
+            solicitud["beneficiario_id"] if solicitud is not None else None,
+        )
+        if value is not None
+    ]
+    if any(value != case_beneficiario_id for value in supplied_beneficiario_ids):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Los registros no pertenecen al mismo beneficiario",
+        )
+
+    assert_resource_owner(estudio["usuario_id"], user, db=db)
+    if solicitud is not None:
+        assert_resource_owner(solicitud["usuario_id"], user, db=db)
+    return dict(estudio), dict(solicitud) if solicitud is not None else None
+
+
 def require_tecnico_or_admin(
     user: Annotated[CurrentUser, Depends(require_auth)],
 ) -> CurrentUser:

--- a/backend/routers/guardar_borrador.py
+++ b/backend/routers/guardar_borrador.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
 from database import get_db, _DBAdapter
-from routers.auth import CurrentUser, assert_resource_owner, require_roles
+from routers.auth import CurrentUser, _assert_case_pair, assert_resource_owner, require_roles
 from routers.socioeconomico import _assert_curp_disponible, _curp_duplicada_error, _resolve_document_preview_url, _resolve_document_refs
 from routers.tecnica import _resolve_storage_url, _BUCKET as _FOTO_BUCKET, _DOCUMENT_BUCKET
 from utils.text import normalize_text
@@ -770,24 +770,36 @@ def _update_borrador(
     if existing is None:
         raise HTTPException(status_code=404, detail="Estudio no encontrado")
 
-    assert_resource_owner(existing["usuario_id"], usuario, db=db)
-
     beneficiario_id = existing["beneficiario_id"]
 
-    # Find solicitud by beneficiario_id (or by solicitud_id if provided)
-    solicitud_existing = None
+    # An explicit solicitud_id is authoritative: authorize that exact row and
+    # never substitute a different solicitud when it is unknown.
     if body.solicitud_id is not None:
-        solicitud_existing = db.execute(
-            "SELECT id FROM solicitudes_tecnicas WHERE id = %s",
-            (body.solicitud_id,),
-        ).fetchone()
-    if solicitud_existing is None:
+        solicitud_id = body.solicitud_id
+    else:
+        # Legacy drafts may omit solicitud_id; only that case may resolve the
+        # latest solicitud associated with the estudio's beneficiary.
         solicitud_existing = db.execute(
             "SELECT id FROM solicitudes_tecnicas WHERE beneficiario_id = %s ORDER BY id DESC LIMIT 1",
             (beneficiario_id,),
         ).fetchone()
+        solicitud_id = solicitud_existing["id"] if solicitud_existing else None
 
-    solicitud_id = solicitud_existing["id"] if solicitud_existing else None
+    if solicitud_id is not None:
+        _assert_case_pair(
+            estudio_id=body.estudio_id,
+            solicitud_id=solicitud_id,
+            beneficiario_id=body.beneficiario_id,
+            user=usuario,
+            db=db,
+        )
+    else:
+        _assert_case_pair(
+            estudio_id=body.estudio_id,
+            beneficiario_id=body.beneficiario_id,
+            user=usuario,
+            db=db,
+        )
 
     try:
         # 1. UPDATE beneficiario (only non-None fields)

--- a/backend/routers/tecnica.py
+++ b/backend/routers/tecnica.py
@@ -14,7 +14,7 @@ from supabase import create_client
 
 from database import get_db, _DBAdapter
 from audit import registrar_evento
-from routers.auth import CurrentUser, assert_resource_owner, require_roles
+from routers.auth import CurrentUser, _assert_case_pair, assert_resource_owner, require_roles
 from validators import (
     validate_padecimiento,
     validate_medida_tecnica,
@@ -1138,6 +1138,11 @@ def crear_solicitud(
     db: Annotated[_DBAdapter, Depends(get_db)],
     usuario: Annotated[CurrentUser, Depends(require_roles("capturista", "organizacion"))],
 ) -> SolicitudCreateResponse:
+    _assert_case_pair(
+        beneficiario_id=body.beneficiario_id,
+        user=usuario,
+        db=db,
+    )
     # Normalize units only on final submission (status=completo).
     # For borradores, store values exactly as sent so open/save cycles
     # are idempotent and do not compound conversion errors.
@@ -1291,7 +1296,7 @@ def actualizar_solicitud(
     if existing is None:
         raise HTTPException(status_code=404, detail="Solicitud no encontrada")
 
-    assert_resource_owner(existing["usuario_id"], usuario, db=db)
+    _assert_case_pair(solicitud_id=id, user=usuario, db=db)
 
     fields = body.model_dump(exclude_none=True)
 
@@ -1299,7 +1304,7 @@ def actualizar_solicitud(
     # contra el estado FUSIONADO (lo enviado en el cuerpo + lo ya persistido en
     # `solicitudes_tecnicas` desde el borrador). Se hace en el endpoint —no en el
     # modelo Pydantic— porque aquí sí hay acceso a la BD. La autorización
-    # (`assert_resource_owner`) ya se evaluó arriba, de modo que un ajeno recibe
+    # (`_assert_case_pair`) ya se evaluó arriba, de modo que un ajeno recibe
     # 403 antes de llegar a esta validación. Mismo enfoque que
     # `finalizar._validate_all_complete`.
     if fields.get("status") == "completo":

--- a/backend/tests/test_containment_pr1.py
+++ b/backend/tests/test_containment_pr1.py
@@ -1,0 +1,294 @@
+"""PR 1 containment tests for correlated case writes.
+
+These tests use FastAPI's real routing/dependency graph with an in-memory DB
+adapter. They intentionally avoid the external PostgreSQL test harness so the
+authorization boundary remains executable without production credentials.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from database import get_db
+from routers import guardar_borrador, tecnica
+from routers.auth import CurrentUser, require_auth
+
+
+OWNER_ID = 10
+LEADER_ID = 20
+MEMBER_ID = 30
+OUTSIDER_ID = 40
+
+
+class Result:
+    def __init__(self, row=None):
+        self.row = row
+
+    def fetchone(self):
+        return self.row
+
+
+class CaseDB:
+    """Small stateful adapter implementing only the PR 1 SQL contract."""
+
+    def __init__(self):
+        self.estudios = {
+            101: {"id": 101, "usuario_id": OWNER_ID, "beneficiario_id": 501},
+            102: {"id": 102, "usuario_id": OUTSIDER_ID, "beneficiario_id": 502},
+            103: {"id": 103, "usuario_id": OWNER_ID, "beneficiario_id": 503},
+        }
+        self.solicitudes = {
+            201: self._solicitud(201, OWNER_ID, 501),
+            202: self._solicitud(202, OUTSIDER_ID, 502),
+        }
+        self.beneficiarios = {
+            501: {"id": 501, "diagnostico": "ORIGINAL", "curp_benef": None},
+            502: {"id": 502, "diagnostico": "OTRO", "curp_benef": None},
+            503: {"id": 503, "diagnostico": "ORIGINAL", "curp_benef": None},
+        }
+        self.leader_pairs = {(LEADER_ID, OWNER_ID)}
+        self.next_solicitud_id = 300
+        self.mutations: list[tuple[str, tuple]] = []
+
+    @staticmethod
+    def _solicitud(solicitud_id: int, user_id: int, beneficiario_id: int) -> dict:
+        return {
+            "id": solicitud_id,
+            "usuario_id": user_id,
+            "beneficiario_id": beneficiario_id,
+            "unidad_captura": "in",
+            "unidad_peso_captura": "kg",
+            "altura_total_in": None,
+            "peso_kg": None,
+            "medida_cabeza_asiento": None,
+            "medida_hombro_asiento": None,
+            "medida_prof_asiento": None,
+            "medida_rodilla_talon": None,
+            "medida_ancho_cadera": None,
+            "status": "borrador",
+            "updated_at": datetime(2026, 7, 10, tzinfo=timezone.utc),
+        }
+
+    def execute(self, sql: str, params=()):
+        normalized = " ".join(sql.split()).lower()
+        params = tuple(params)
+
+        if "select 1 from organizaciones" in normalized:
+            return Result({"?column?": 1} if (params[0], params[2]) in self.leader_pairs else None)
+
+        if "from estudios_socioeconomicos" in normalized:
+            if "where id = %s" in normalized:
+                return Result(self.estudios.get(params[0]))
+            if "where beneficiario_id = %s" in normalized:
+                row = next(
+                    (row for row in self.estudios.values() if row["beneficiario_id"] == params[0]),
+                    None,
+                )
+                return Result(row)
+
+        if "from solicitudes_tecnicas" in normalized:
+            if "where id = %s" in normalized:
+                return Result(self.solicitudes.get(params[0]))
+            if "where beneficiario_id = %s and usuario_id = %s" in normalized:
+                row = next(
+                    (
+                        row
+                        for row in self.solicitudes.values()
+                        if row["beneficiario_id"] == params[0] and row["usuario_id"] == params[1]
+                    ),
+                    None,
+                )
+                return Result(row)
+            if "where beneficiario_id = %s" in normalized:
+                row = next(
+                    (row for row in self.solicitudes.values() if row["beneficiario_id"] == params[0]),
+                    None,
+                )
+                return Result(row)
+
+        if normalized.startswith("insert into solicitudes_tecnicas"):
+            solicitud_id = self.next_solicitud_id
+            self.next_solicitud_id += 1
+            self.solicitudes[solicitud_id] = self._solicitud(solicitud_id, params[1], params[0])
+            self.mutations.append(("insert_solicitud", params))
+            return Result({"id": solicitud_id})
+
+        if normalized.startswith("update beneficiarios set diagnostico"):
+            self.beneficiarios[params[1]]["diagnostico"] = params[0]
+            self.mutations.append(("update_diagnostico", params))
+            return Result()
+
+        if normalized.startswith("update solicitudes_tecnicas set"):
+            solicitud_id = params[-1]
+            if "prioridad = %s" in normalized:
+                self.solicitudes[solicitud_id]["prioridad"] = params[0]
+            self.solicitudes[solicitud_id]["updated_at"] = datetime.now(timezone.utc)
+            self.mutations.append(("update_solicitud", params))
+            return Result()
+
+        if "select curp_benef from beneficiarios" in normalized:
+            return Result(self.beneficiarios.get(params[0]))
+
+        raise AssertionError(f"Unexpected SQL in PR 1 test adapter: {normalized}")
+
+    def rollback(self):
+        return None
+
+
+def _user(user_id: int, role: str = "capturista") -> CurrentUser:
+    return CurrentUser(
+        usuario_id=user_id,
+        nombre=f"User {user_id}",
+        email=f"user{user_id}@example.test",
+        rol=role,
+    )
+
+
+@pytest.fixture
+def case_db():
+    return CaseDB()
+
+
+@pytest.fixture
+def api_client(case_db, request):
+    app = FastAPI()
+    app.include_router(tecnica.router, prefix="/api")
+    app.include_router(guardar_borrador.router, prefix="/api")
+    current_user = getattr(request, "param", _user(OWNER_ID))
+    app.dependency_overrides[get_db] = lambda: case_db
+    app.dependency_overrides[require_auth] = lambda: current_user
+    with TestClient(app) as client:
+        yield client
+
+
+def _create_payload(beneficiario_id: int, *, diagnostico: str | None = None) -> dict:
+    payload = {
+        "beneficiario_id": beneficiario_id,
+        "entorno": "Urbano / Interiores",
+        "control_tronco": "Completo",
+        "control_cabeza": "Independiente",
+        "control_de_piernas": "Parcial",
+        "status": "borrador",
+    }
+    if diagnostico is not None:
+        payload["diagnostico"] = diagnostico
+    return payload
+
+
+def test_owner_correlated_post_write_201(api_client, case_db):
+    response = api_client.post("/api/solicitudes", json=_create_payload(503))
+
+    assert response.status_code == 201, response.text
+    assert response.json()["beneficiario_id"] == 503
+    assert any(kind == "insert_solicitud" for kind, _ in case_db.mutations)
+
+
+@pytest.mark.parametrize("api_client", [_user(OUTSIDER_ID)], indirect=True)
+def test_cross_user_post_write_403_without_mutation(api_client, case_db):
+    response = api_client.post("/api/solicitudes", json=_create_payload(503))
+
+    assert response.status_code == 403
+    assert case_db.mutations == []
+
+
+@pytest.mark.parametrize(
+    ("api_client", "expected"),
+    [(_user(LEADER_ID, "organizacion"), 201), (_user(MEMBER_ID, "organizacion"), 403)],
+    indirect=["api_client"],
+)
+def test_org_leader_allowed_plain_member_denied_on_post(api_client, expected):
+    response = api_client.post("/api/solicitudes", json=_create_payload(503))
+
+    assert response.status_code == expected, response.text
+
+
+def test_owner_correlated_patch_write_200(api_client, case_db):
+    response = api_client.patch("/api/solicitudes/201", json={"prioridad": "Alta"})
+
+    assert response.status_code == 200, response.text
+    assert case_db.solicitudes[201]["prioridad"] == "Alta"
+
+
+@pytest.mark.parametrize("api_client", [_user(OUTSIDER_ID)], indirect=True)
+def test_cross_user_patch_write_403_without_mutation(api_client, case_db):
+    response = api_client.patch("/api/solicitudes/201", json={"prioridad": "Alta"})
+
+    assert response.status_code == 403
+    assert case_db.mutations == []
+
+
+@pytest.mark.parametrize(
+    ("api_client", "expected"),
+    [(_user(LEADER_ID, "organizacion"), 200), (_user(MEMBER_ID, "organizacion"), 403)],
+    indirect=["api_client"],
+)
+def test_org_leader_allowed_plain_member_denied_on_patch(api_client, expected):
+    response = api_client.patch("/api/solicitudes/201", json={"prioridad": "Media"})
+
+    assert response.status_code == expected, response.text
+
+
+def test_mismatched_beneficiary_and_solicitud_returns_422(api_client, case_db):
+    response = api_client.post(
+        "/api/guardar-borrador",
+        json={"estudio_id": 101, "solicitud_id": 202, "beneficiario_id": 501},
+    )
+
+    assert response.status_code == 422, response.text
+    assert case_db.mutations == []
+
+
+def test_unknown_explicit_solicitud_id_returns_404_without_fallback(api_client, case_db):
+    response = api_client.post(
+        "/api/guardar-borrador",
+        json={"estudio_id": 101, "solicitud_id": 999, "beneficiario_id": 501},
+    )
+
+    assert response.status_code == 404, response.text
+    assert case_db.solicitudes[201]["updated_at"] == datetime(2026, 7, 10, tzinfo=timezone.utc)
+    assert case_db.mutations == []
+
+
+def test_owner_diagnostico_post_mutates_authorized_beneficiary(api_client, case_db):
+    response = api_client.post(
+        "/api/solicitudes",
+        json=_create_payload(503, diagnostico="Lesión medular"),
+    )
+
+    assert response.status_code == 201, response.text
+    assert case_db.beneficiarios[503]["diagnostico"] == "LESION MEDULAR"
+
+
+@pytest.mark.parametrize("api_client", [_user(OUTSIDER_ID)], indirect=True)
+def test_diagnostico_post_requires_beneficiary_estudio_authorization(api_client, case_db):
+    response = api_client.post(
+        "/api/solicitudes",
+        json=_create_payload(503, diagnostico="No autorizado"),
+    )
+
+    assert response.status_code == 403
+    assert case_db.beneficiarios[503]["diagnostico"] == "ORIGINAL"
+
+
+def test_owner_diagnostico_patch_mutates_authorized_beneficiary(api_client, case_db):
+    response = api_client.patch(
+        "/api/solicitudes/201",
+        json={"diagnostico": "Lesión medular"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert case_db.beneficiarios[501]["diagnostico"] == "LESION MEDULAR"
+
+
+def test_diagnostico_patch_requires_matching_estudio_authorization(api_client, case_db):
+    case_db.estudios[101]["usuario_id"] = OUTSIDER_ID
+
+    response = api_client.patch(
+        "/api/solicitudes/201",
+        json={"diagnostico": "No autorizado"},
+    )
+
+    assert response.status_code == 403
+    assert case_db.beneficiarios[501]["diagnostico"] == "ORIGINAL"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 email-validator==2.2.0
 openpyxl>=3.1.0
+pytest==8.4.2


### PR DESCRIPTION
Closes #178

## Summary

- Enforce server-side ownership and shared-case correlation for draft and technical writes.
- Make explicitly supplied technical-request IDs authoritative; unknown IDs return 404 without fallback.
- Protect diagnostic updates while preserving valid owner and organization-leader workflows.

## Chain context

**Strategy:** sequential PRs targeting `branch-beta03`.

```text
branch-beta03
└── PR 1: Case authorization and correlation 📍
    ├── PR 2: Finalization correlation
    ├── PR 3: Resource-ID document route
    ├── PR 4: Draft-only and completed immutability
    └── PR 5: Safe DOM and centralized logout
```

- **Start state:** affected writes do not consistently prove ownership and one shared case boundary.
- **End state:** PR 1 endpoints reject cross-user, plain-member, mismatched, and unknown explicit-ID mutations.
- **Prior dependency:** none beyond `branch-beta03`.
- **Follow-up work:** PRs 2–5 remain out of scope.

## Changes

| File | Change |
|---|---|
| `backend/routers/auth.py` | Add shared case authorization and correlation helper. |
| `backend/routers/guardar_borrador.py` | Enforce exact request-ID handling and case checks. |
| `backend/routers/tecnica.py` | Gate technical and diagnostic writes by case ownership. |
| `backend/tests/test_containment_pr1.py` | Cover owner, leader, denial, mismatch, and unknown-ID behavior. |
| `requirements.txt`, `backend/requirements.txt` | Declare the focused test runtime dependencies. |

## Verification

- [x] `.venv/bin/python -m pytest backend/tests/test_containment_pr1.py -q` — 14 passed.
- [x] `.venv/bin/python -m pytest backend/tests/test_auth_helpers.py -q` — 5 passed.
- [x] `.venv/bin/python -m pytest --collect-only -q` — 825 tests collected.
- [x] `git diff --check` and staged diff check passed.
- [x] Native high-risk 4R review approved under lineage `review-b481db1562376a60`.
- [x] `pre-commit`, `pre-push`, and `pre-pr` lifecycle gates allowed delivery.

## Review-size exception

Maintainer-approved `size:exception`: **391 additions + 15 deletions = 406 changed lines**. This is six lines above the standard threshold and remains below the configured 800-line slice budget. The focused 294-line regression harness stays with the behavior it proves; splitting it would weaken the work-unit boundary.

## Rollback

Revert commit `9c43896` to remove only PR 1 dependencies, authorization/correlation behavior, and its focused regression tests.

## Checklist

- [x] Linked approved issue #178.
- [x] Added exactly one `type:*` label: `type:bug`.
- [x] Used a conventional commit with no attribution trailers.
- [x] Kept unrelated README, audit, and OpenSpec changes outside the PR.
- [x] Recorded focused tests, runtime harness evidence, and rollback boundary.